### PR TITLE
Change to JSDoc type formatting {type}

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -55,9 +55,9 @@ function resetEnqLinkTimer() {
 /**
  * Client session function - inherits from session()
  *
- * @param obj sock - socket object
- * @param obj options - as derived from client()
- * @return obj (returnObj)
+ * @param {object} sock - socket object
+ * @param {object} options - as derived from client()
+ * @return {object} (returnObj)
  */
 function clientSession(sock, options) {
 	var returnObj = session(sock);
@@ -89,10 +89,10 @@ function clientSession(sock, options) {
 }
 
 /**
- * Setup a client
+ * Setup a client.
  *
- * @param obj options - host, port, username, password
- * @param func callback(err, session)
+ * @param {object} options - host, port, username, password, tls, enqLinkTiming
+ * @param {function} callback(err, session)
  */
 function client(options, callback) {
 	var sock;

--- a/lib/server.js
+++ b/lib/server.js
@@ -10,7 +10,7 @@ var log       = require('winston'),
 /**
  * Try to log a connecting peer in
  *
- * @param obj pduObj
+ * @param {object} pduObj
  */
 function login(pduObj) {
 	var that = this;
@@ -97,9 +97,9 @@ function resetEnqLinkTimer() {
 /**
  * Server session function - inherits from session()
  *
- * @param obj sock - socket object
- * @param obj options - as derived from server()
- * @return obj (returnObj)
+ * @param {object} sock - socket object
+ * @param {object} options - as derived from server()
+ * @return {object} (returnObj)
  */
 function serverSession(sock, options) {
 	var returnObj = session(sock);
@@ -143,8 +143,8 @@ function serverSession(sock, options) {
 /**
  * Setup a server
  *
- * @param obj options - host, port, checkuserpass() etc (OPTIONAL)
- * @param func callback(err, session)
+ * @param {object} options - host, port, checkuserpass() etc (OPTIONAL)
+ * @param {function} callback(err, session)
  */
 function server(options, callback) {
 	var tlsOrNet;
@@ -174,7 +174,7 @@ function server(options, callback) {
 		var returnObj = serverSession(sock, options);
 
 		// We have a connection - a socket object is assigned to the connection automatically
-		log.verbose('larvitsmpp: lib/server.js: server() - Incomming connection! From: ' + sock.remoteAddress + ':' + sock.remotePort);
+		log.verbose('larvitsmpp: lib/server.js: server() - Incoming connection! From: ' + sock.remoteAddress + ':' + sock.remotePort);
 
 		callback(null, returnObj);
 	}).listen(options.port, options.host);

--- a/lib/session.js
+++ b/lib/session.js
@@ -103,8 +103,8 @@ function closeSocket() {
 /**
  * Write PDU to socket
  *
- * @param buf or obj pdu - can also take PDU object
- * @param bol closeAfterSend - if true will close the socket after sending
+ * @param {buffer|object} pdu - can also take PDU object
+ * @param {boolean} closeAfterSend - if true will close the socket after sending
  */
 function sockWrite(pdu, closeAfterSend) {
 	var that = this;
@@ -139,9 +139,9 @@ function sockWrite(pdu, closeAfterSend) {
 /**
  * Send a PDU to the remote
  *
- * @param buf or obj pdu
- * @param bol closeAfterSend - Will close after return is fetched. Defaults to false (OPTIONAL)
- * @param func callback(err, retPdu) (OPTIONAL)
+ * @param {buffer|object} pdu
+ * @param {boolean} closeAfterSend - Will close after return is fetched. Defaults to false (OPTIONAL)
+ * @param {function} callback(err, retPdu) (OPTIONAL)
  */
 function send(pdu, closeAfterSend, callback) {
 	var pduObj = pdu,
@@ -213,11 +213,11 @@ function send(pdu, closeAfterSend, callback) {
 /**
  * Send a return to given PDU
  *
- * @param obj or buf pdu
- * @param str status - see list at defs.errors - defaults to 'ESME_ROK' - no error (OPTIONAL)
- * @param obj params (OPTIONAL)
- * @param bol closeAfterSend - if true will close the socket after sending (OPTIONAL)
- * @param func callback(err, retPdu) (OPTIONAL)
+ * @param {buffer|object} pdu
+ * @param {string} status - see list at defs.errors - defaults to 'ESME_ROK' - no error (OPTIONAL)
+ * @param {object} [params]
+ * @param {boolean} closeAfterSend - if true will close the socket after sending (OPTIONAL)
+ * @param {function} [callback(err, retPdu)]
  */
 function sendReturn(pdu, status, params, closeAfterSend, callback) {
 	var that = this;
@@ -259,13 +259,13 @@ function sendReturn(pdu, status, params, closeAfterSend, callback) {
 /**
  * Send an SMS
  *
- * @param obj smsOptions
+ * @param {object} smsOptions
  *                       from - alphanum or international format
  *                       to - international format
  *                       message - string
  *                       dlr - boolean defaults to false
  *                       flash - boolean defaults to false
- * @param func callback(err, smsIds, retPduObjs)
+ * @param {function} callback(err, smsIds, retPduObjs)
  */
 function sendSms(smsOptions, callback) {
 	var pduObj = {};
@@ -310,12 +310,12 @@ function sendSms(smsOptions, callback) {
 /**
  * Send a longer SMS than 1120 bits
  *
- * @param obj smsOptions
+ * @param {object} smsOptions
  *                       from - alphanum or international format
  *                       to - international format
  *                       message - string
  *                       dlr - boolean defaults to false
- * @param func callback(err, smsId, retPduObj)
+ * @param {function} callback(err, smsId, retPduObj)
  */
 function sendLongSms(smsOptions, callback) {
 	var that       = this,
@@ -483,8 +483,8 @@ function checkLongSmses() {
 /**
  * Generic session function
  *
- * @param obj sock - socket object
- * @return obj (returnObj)
+ * @param {object} sock - socket object
+ * @return {object} (returnObj)
  */
 function session(sock) {
 	var returnObj = new events.EventEmitter();
@@ -508,10 +508,10 @@ function session(sock) {
 	returnObj.utils       = utils;
 
 	// Temporary storage for long sms parts
-	// These should be cleared if they lingre to long to avoid memory leaks
+	// These should be cleared if they linger to long to avoid memory leaks
 	returnObj.longSmses = {};
 
-	// Temporary storage for DLRs to long smses
+	// Temporary storage for DLRs to long SMSes
 	// We keep them like this to be able to simulate a single DLR when all parts have gotten DLRs
 	returnObj.longSmsDlrs = {};
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,10 +5,10 @@ var log         = require('winston'),
     bundleMsgId = 0;
 
 /**
- * Calcualte cmdLength from object
+ * Calculate cmdLength from object
  *
- * @param obj obj
- * @param func callback(err, cmdLength)
+ * @param {object} obj
+ * @param {function} callback(err, cmdLength)
  */
 function calcCmdLength(obj, callback) {
 	var cmdLength = 16, // All commands are at least 16 octets long
@@ -65,9 +65,9 @@ function calcCmdLength(obj, callback) {
 /**
  * Write PDU to buffer
  *
- * @param obj obj - the PDU object to be written to buffer
- * @param int cmdLength - The length of the pdu buffer
- * @param func callback(err, buff)
+ * @param {object} obj - the PDU object to be written to buffer
+ * @param {number} cmdLength - The length of the pdu buffer
+ * @param {function} callback(err, buff)
  */
 function writeBuffer(obj, cmdLength, callback) {
 	var offset = 16, // Start the offset on the body
@@ -162,10 +162,10 @@ function writeBuffer(obj, cmdLength, callback) {
 /**
  * Decode a short_message
  *
- * @param buf buffer
- * @param str encoding 'ASCII', 'LATIN1' or 'UCS2' or hex values
- * @param int offset - defaults to 0
- * @return str in utf8 format
+ * @param {buffer} buffer
+ * @param {string} encoding 'ASCII', 'LATIN1' or 'UCS2' or hex values
+ * @param {number} offset - defaults to 0
+ * @return {string} in utf8 format
  */
 function decodeMsg(buffer, encoding, offset) {
 	var checkEnc;
@@ -199,9 +199,9 @@ function encodeMsg(str) {
 /**
  * Transforms a PDU to an object
  *
- * @param buf pdu
- * @param bol stupidNullByte - Define if the short_message should be followed by a stupid NULL byte - will be auto resolved if left undefined
- * @param func callback(err, obj)
+ * @param {buffer} pdu
+ * @param {boolean} stupidNullByte - Define if the short_message should be followed by a stupid NULL byte - will be auto resolved if left undefined
+ * @param {function} callback(err, obj)
  */
 function pduToObj(pdu, stupidNullByte, callback) {
 	var retObj = {'params': {}, 'tlvs': {}},
@@ -359,8 +359,8 @@ function pduToObj(pdu, stupidNullByte, callback) {
 /**
  * Transform an object to a PDU
  *
- * @param obj obj - example {'cmdName': 'bind_transceiver_resp', 'cmdStatus': 'ESME_ROK', 'seqNr': 2} - to add parameters add a key 'params' as object
- * @param func callback(err, pdu)
+ * @param {object} obj - example {'cmdName': 'bind_transceiver_resp', 'cmdStatus': 'ESME_ROK', 'seqNr': 2} - to add parameters add a key 'params' as object
+ * @param {function} callback(err, pdu)
  */
 function objToPdu(obj, callback) {
 	var err = null,
@@ -438,11 +438,11 @@ function objToPdu(obj, callback) {
 /**
  * Create a PDU as a return to another PDU
  *
- * @param obj or buf pdu
- * @param str status - see list at defs.errors - defaults to 'ESME_ROK' - no error (OPTIONAL)
- * @param obj params (OPTIONAL)
- * @param obj tlvs (OPTIONAL)
- * @param func callback(err, pduBuffer) (OPTIONAL)
+ * @param {object|buffer} pdu
+ * @param {string} status - see list at defs.errors - defaults to 'ESME_ROK' - no error (OPTIONAL)
+ * @param {object} [params]
+ * @param {object} [tlvs]
+ * @param {function} [callback(err, pduBuffer)]
  */
 function pduReturn(pdu, status, params, tlvs, callback) {
 	var err    = null,
@@ -544,8 +544,8 @@ function pduReturn(pdu, status, params, tlvs, callback) {
 /**
  * Format a js date object as ugly SMPP date format
  *
- * @param obj jsDateObj
- * @return str
+ * @param {object} jsDateObj
+ * @return {string}
  */
 function smppDate(jsDateObj) {
 	var uglyStr = '';
@@ -582,8 +582,8 @@ function smppDate(jsDateObj) {
 /**
  * Calculate bitCount of short_message
  *
- * @param str msg
- * @param str encoding - Force encoding ASCII or UCS2 (OPTIONAL)
+ * @param {string} msg
+ * @param {string} encoding - Force encoding ASCII or UCS2 (OPTIONAL)
  * @return integer
  */
 function bitCount(msg, encoding) {
@@ -601,8 +601,8 @@ function bitCount(msg, encoding) {
 /**
  * Split a message into multiple messages
  *
- * @param str msg
- * @param str encoding - Force encoding ASCII or UCS2 (OPTIONAL)
+ * @param {string} msg
+ * @param {string} encoding - Force encoding ASCII or UCS2 (OPTIONAL)
  * @return array of buffers
  */
 function splitMsg(msg, encoding) {
@@ -691,8 +691,8 @@ function splitMsg(msg, encoding) {
  * Send a dlr to an sms
  * This must be called from an sms object context
  *
- * @param str status - see list at defs.consts.MESSAGE_STATE - defaults to 'DELIVERED'
- * @param func callback(err, retPdu, dlrPduObj)
+ * @param {string} status - see list at defs.consts.MESSAGE_STATE - defaults to 'DELIVERED'
+ * @param {function} callback(err, retPdu, dlrPduObj)
  */
 function smsDlr(status, callback) {
 	var shortMessage,


### PR DESCRIPTION
While I was browsing the code my IDE was complaining about the JSDoc format. This format with the complete names is the right one. 