### PR TITLE
Fix LATIN1 decode test

### DIFF
--- a/test/01_encodings.js
+++ b/test/01_encodings.js
@@ -88,7 +88,7 @@ describe('encodings', function() {
 				var str;
 
 				for (str in samples) {
-					assert.deepEqual(LATIN1.decode(samples[str]), str);
+					assert.deepEqual(LATIN1.decode(new Buffer(samples[str])), str);
 				}
 			});
 		});


### PR DESCRIPTION
It does not work as the latest version of the decode function requires a Buffer, not just an array.

This is one of the tests that currently fail for #18 