### PR TITLE
Use project eslint and mocha instead of global ones

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "pre-git": {
       "commit-msg": "",
       "pre-commit": [
-        "eslint ./",
-        "mocha"
+        "./node_modules/.bin/eslint ./",
+        "./node_modules/.bin/mocha"
       ],
       "pre-push": [],
       "post-commit": [],


### PR DESCRIPTION
As those are listed in `devDependencies`, developers should not be forced to install them globally.