### PR TITLE
fix: message_id in submit_sm_resp + SMPP spec compliant DLR stat codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,43 +4,53 @@
 
 
 
-# My Contributions
+This is a fork of [larvit/larvitsmpp](https://github.com/larvit/larvitsmpp) 
+with critical fixes for **Kannel SMS Gateway** + **Redis DLR** compatibility.
 
+---
 
-### Problems fixed:
-- submit_sm_resp was sent without message_id, causing Kannel to store
-  DLR entries in Redis with key ts=0, making DLR matching impossible
-- multipart (long) SMS parts also had no message_id in their responses
-- stat field in DLR message body was 'UNDELIVERABLE' instead of SMPP
-  spec compliant 'UNDELIV' (7 chars), causing Kannel to ignore the
-  status and always mark as DELIVRD
-- smsId was never set on server-side smsObj, causing smsDlr() to bail
-  out with 'Trying to send DLR with no smsId' error
+## What's Fixed in This Fork
 
-### Changes:
-  lib/session.js
-  - Generate UUID message_id before sending submit_sm_resp (single part)
-  - Generate UUID message_id per part in longSms() (multipart)
-  - Store msgId on longSmses group so checkLongSmses() can use it
-  - Set smsId on smsObj for both single and multipart assembled messages
-  - Move sendReturn() call to happen before emitting sms event
+### 1. Missing `message_id` in `submit_sm_resp` (Single Part SMS)
+**Problem:** larvitsmpp was sending `submit_sm_resp` without a `message_id`.
+Kannel stores DLR entries in Redis using this ID. Without it, the Redis key
+was `bb_dlr:SMSC:0` and DLRs could never be matched or delivered.
 
-  lib/utils.js
-  - Fix stat:UNDELIVERABLE -> stat:UNDELIV in DLR short_message body
-  - Fix dlvrd field to correctly reflect delivery status
+**Fix:** A UUID is now generated and returned as `message_id` in every
+`submit_sm_resp`, and stored as `smsId` on the `smsObj` for later DLR use.
 
-  lib/defs.js
-  - Fix MESSAGE_STATE key mappings for correct UNDELIV status routing
+---
 
-  app.js
-  - Add the DLRs return logic
+### 2. Missing `message_id` in `submit_sm_resp` (Multipart/Long SMS)
+**Problem:** For multipart messages, the code returned early with
+`returnObj.longSms(pduObj)` before sending any `submit_sm_resp`.
+No `message_id` was ever sent back to Kannel for any part.
 
+**Fix:** `longSms()` now generates a UUID per part and sends
+`submit_sm_resp` with `message_id` immediately. The first part's ID
+is stored on the group and later set as `smsId` on the assembled `smsObj`.
 
-### Tested with:
-  - Kannel SMS gateway + Redis DLR storage
-  - Single part SMS DLR flow (DELIVRD and UNDELIV)
-  - Multipart (concatenated) SMS DLR flow
-  - Wireshark PCAP verified correct message_id in submit_sm_resp PDU"
+---
+
+### 3. `smsId` Never Set on Server-Side `smsObj`
+**Problem:** `smsDlr()` in `utils.js` checks `if (sms.smsId === undefined)`
+and bails out with a warning. On the server side, `smsId` was never
+populated on the `smsObj`, so `sendDlr()` always failed silently.
+
+**Fix:** `smsId` is now explicitly set on `smsObj` for both single
+and multipart messages.
+
+---
+
+### 4. `stat:UNDELIVERABLE` Instead of `stat:UNDELIV`
+**Problem:** The SMPP v3.4 spec requires the `stat` field in the DLR
+message body to be exactly 7 characters. larvitsmpp was sending
+`stat:UNDELIVERABLE` (13 chars). Kannel's sscanf parser rejected it
+and fell back to treating every DLR as `DELIVRD`.
+
+**Fix:** Changed to spec-compliant `stat:UNDELIV`.
+
+---
 
 # Larv IT SMPP
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,46 @@
 [![Dependencies](https://david-dm.org/larvit/larvitsmpp.svg)](https://david-dm.org/larvit/larvitsmpp.svg)
 [![Coverage Status](https://coveralls.io/repos/larvit/larvitsmpp/badge.svg)](https://coveralls.io/github/larvit/larvitsmpp)
 
+
+
+# My Contributions
+
+
+### Problems fixed:
+- submit_sm_resp was sent without message_id, causing Kannel to store
+  DLR entries in Redis with key ts=0, making DLR matching impossible
+- multipart (long) SMS parts also had no message_id in their responses
+- stat field in DLR message body was 'UNDELIVERABLE' instead of SMPP
+  spec compliant 'UNDELIV' (7 chars), causing Kannel to ignore the
+  status and always mark as DELIVRD
+- smsId was never set on server-side smsObj, causing smsDlr() to bail
+  out with 'Trying to send DLR with no smsId' error
+
+### Changes:
+  lib/session.js
+  - Generate UUID message_id before sending submit_sm_resp (single part)
+  - Generate UUID message_id per part in longSms() (multipart)
+  - Store msgId on longSmses group so checkLongSmses() can use it
+  - Set smsId on smsObj for both single and multipart assembled messages
+  - Move sendReturn() call to happen before emitting sms event
+
+  lib/utils.js
+  - Fix stat:UNDELIVERABLE -> stat:UNDELIV in DLR short_message body
+  - Fix dlvrd field to correctly reflect delivery status
+
+  lib/defs.js
+  - Fix MESSAGE_STATE key mappings for correct UNDELIV status routing
+
+  app.js
+  - Add the DLRs return logic
+
+
+### Tested with:
+  - Kannel SMS gateway + Redis DLR storage
+  - Single part SMS DLR flow (DELIVRD and UNDELIV)
+  - Multipart (concatenated) SMS DLR flow
+  - Wireshark PCAP verified correct message_id in submit_sm_resp PDU"
+
 # Larv IT SMPP
 
 This is a simplified implementation of the SMPP protocol.

--- a/lib/defs.js
+++ b/lib/defs.js
@@ -2,365 +2,361 @@
 
 // More or less copied from https://github.com/farhadi/node-smpp
 
-const	topLogPrefix	= 'larvitsmpp: lib/defs.js: ',
-	constsById	= {},
-	errorsById	= {},
-	encodings	= {},
-	tlvsById	= {},
-	cmdsById	= {},
-	filters	= {},
-	errors	= {},
-	consts	= {},
-	types	= {},
-	tlvs	= {},
-	cmds	= {},
-	iconv	= require('iconv-lite'),
-	LUtils	= require('larvitutils'),
-	lUtils	= new LUtils(),
-	log	= new lUtils.Log('error');
+var log        = require('winston'),
+    iconv      = require('iconv-lite'),
+    encodings  = {},
+    filters    = {},
+    tlvsById   = {},
+    constsById = {},
+    types,
+    consts,
+    constGrp,
+    constName,
+    tlvs,
+    tag,
+    cmds,
+    cmdsById,
+    command,
+    errors,
+    errorsById,
+    error;
 
-consts.REGISTERED_DELIVERY = {
-	'FINAL':	0x01,
-	'FAILURE':	0x02,
-	'SUCCESS':	0x03,
-	'DELIVERY_ACKNOWLEDGEMENT':	0x04,
-	'USER_ACKNOWLEDGEMENT':	0x08,
-	'INTERMEDIATE':	0x10
-};
-consts.ESM_CLASS = {
-	'DATAGRAM':	0x01,
-	'FORWARD':	0x02,
-	'STORE_FORWARD':	0x03,
-	'MC_DELIVERY_RECEIPT':	0x04,
-	'DELIVERY_ACKNOWLEDGEMENT':	0x08,
-	'USER_ACKNOWLEDGEMENT':	0x10,
-	'CONVERSATION_ABORT':	0x18,
-	'INTERMEDIATE_DELIVERY':	0x20,
-	'UDH_INDICATOR':	0x40,
-	'SET_REPLY_PATH':	0x80
-};
-consts.MESSAGE_STATE = {
-	'SCHEDULED':	0,
-	'ENROUTE':	1,
-	'DELIVERED':	2,
-	'EXPIRED':	3,
-	'DELETED':	4,
-	'UNDELIVERABLE':	5,
-	'ACCEPTED':	6,
-	'UNKNOWN':	7,
-	'REJECTED':	8,
-	'SKIPPED':	9
-};
-consts.TON = {
-	'UNKNOWN':	0x00,
-	'INTERNATIONAL':	0x01,
-	'NATIONAL':	0x02,
-	'NETWORK_SPECIFIC':	0x03,
-	'SUBSCRIBER_NUMBER':	0x04,
-	'ALPHANUMERIC':	0x05,
-	'ABBREVIATED':	0x06
-};
-consts.NPI = {
-	'UNKNOWN':	0x00,
-	'ISDN':	0x01,
-	'DATA':	0x03,
-	'TELEX':	0x04,
-	'LAND_MOBILE':	0x06,
-	'NATIONAL':	0x08,
-	'PRIVATE':	0x09,
-	'ERMES':	0x0A,
-	'INTERNET':	0x0E,
-	'IP':	0x0E,
-	'WAP':	0x12
-};
-consts.ENCODING = {
-	'ASCII':	0x01,
-	'IA5':	0x01,
-	'LATIN1':	0x03,
-	'ISO_8859_1':	0x03,
-	'BINARY':	0x04,
-	'JIS':	0x05,
-	'X_0208_1990':	0x05,
-	'CYRILLIC':	0x06,
-	'ISO_8859_5':	0x06,
-	'HEBREW':	0x07,
-	'ISO_8859_8':	0x07,
-	'UCS2':	0x08,
-	'PICTOGRAM':	0x09,
-	'ISO_2022_JP':	0x0A,
-	'EXTENDED_KANJI_JIS':	0x0D,
-	'X_0212_1990':	0x0D,
-	'KS_C_5601':	0x0E,
-	'FLASH':	0x10
-};
-consts.NETWORK = {
-	'GENERIC':	0x00,
-	'GSM':	0x01,
-	'TDMA':	0x02,
-	'CDMA':	0x03
-};
-consts.BROADCAST_AREA_FORMAT = {
-	'NAME':	0x00,
-	'ALIAS':	0x00,
-	'ELLIPSOID_ARC':	0x01,
-	'POLYGON':	0x02
-};
-consts.BROADCAST_FREQUENCY_INTERVAL = {
-	'MAX_POSSIBLE':	0x00,
-	'SECONDS':	0x08,
-	'MINUTES':	0x09,
-	'HOURS':	0x0A,
-	'DAYS':	0x0B,
-	'WEEKS':	0x0C,
-	'MONTHS':	0x0D,
-	'YEARS':	0x0E
+consts = {
+	REGISTERED_DELIVERY: {
+		FINAL:                    0x01,
+		FAILURE:                  0x02,
+		SUCCESS:                  0x03,
+		DELIVERY_ACKNOWLEDGEMENT: 0x04,
+		USER_ACKNOWLEDGEMENT:     0x08,
+		INTERMEDIATE:             0x10
+	},
+	ESM_CLASS: {
+		DATAGRAM:                 0x01,
+		FORWARD:                  0x02,
+		STORE_FORWARD:            0x03,
+		MC_DELIVERY_RECEIPT:      0x04,
+		DELIVERY_ACKNOWLEDGEMENT: 0x08,
+		USER_ACKNOWLEDGEMENT:     0x10,
+		CONVERSATION_ABORT:       0x18,
+		INTERMEDIATE_DELIVERY:    0x20,
+		UDH_INDICATOR:            0x40,
+		SET_REPLY_PATH:           0x80
+	},
+	MESSAGE_STATE: {
+		SCHEDULED:     0,
+		ENROUTE:       1,
+		DELIVRD:     2,
+		EXPIRED:       3,
+		DELETED:       4,
+		UNDELIV: 5,
+		ACCEPTED:      6,
+		UNKNOWN:       7,
+		REJECTED:      8,
+		SKIPPED:       9
+	},
+	TON: {
+		UNKNOWN:           0x00,
+		INTERNATIONAL:     0x01,
+		NATIONAL:          0x02,
+		NETWORK_SPECIFIC:  0x03,
+		SUBSCRIBER_NUMBER: 0x04,
+		ALPHANUMERIC:      0x05,
+		ABBREVIATED:       0x06
+	},
+	NPI: {
+		UNKNOWN:     0x00,
+		ISDN:        0x01,
+		DATA:        0x03,
+		TELEX:       0x04,
+		LAND_MOBILE: 0x06,
+		NATIONAL:    0x08,
+		PRIVATE:     0x09,
+		ERMES:       0x0A,
+		INTERNET:    0x0E,
+		IP:          0x0E,
+		WAP:         0x12
+	},
+	ENCODING: {
+		ASCII:              0x01,
+		IA5:                0x01,
+		LATIN1:             0x03,
+		ISO_8859_1:         0x03,
+		BINARY:             0x04,
+		JIS:                0x05,
+		X_0208_1990:        0x05,
+		CYRILLIC:           0x06,
+		ISO_8859_5:         0x06,
+		HEBREW:             0x07,
+		ISO_8859_8:         0x07,
+		UCS2:               0x08,
+		PICTOGRAM:          0x09,
+		ISO_2022_JP:        0x0A,
+		EXTENDED_KANJI_JIS: 0x0D,
+		X_0212_1990:        0x0D,
+		KS_C_5601:          0x0E,
+		FLASH:              0x10
+	},
+	NETWORK: {
+		GENERIC: 0x00,
+		GSM:     0x01,
+		TDMA:    0x02,
+		CDMA:    0x03
+	},
+	BROADCAST_AREA_FORMAT: {
+		NAME:          0x00,
+		ALIAS:         0x00,
+		ELLIPSOID_ARC: 0x01,
+		POLYGON:       0x02
+	},
+	BROADCAST_FREQUENCY_INTERVAL: {
+		MAX_POSSIBLE: 0x00,
+		SECONDS:      0x08,
+		MINUTES:      0x09,
+		HOURS:        0x0A,
+		DAYS:         0x0B,
+		WEEKS:        0x0C,
+		MONTHS:       0x0D,
+		YEARS:        0x0E
+	}
 };
 
-for (const constGrp in consts) {
+for (constGrp in consts) {
 	if (constsById[constGrp] === undefined) {
-		constsById[constGrp]	= {};
+		constsById[constGrp] = {};
 	}
 
-	for (const constName in consts[constGrp]) {
-		constsById[constGrp][consts[constGrp][constName]]	= constName;
+	for (constName in consts[constGrp]) {
+		constsById[constGrp][consts[constGrp][constName]] = constName;
 	}
 }
 
-types.int8 = {
-	'read': function read(buffer, offset) {
-		return buffer.readUInt8(offset);
-	},
-	'write': function write(value, buffer, offset) {
-		const	logPrefix	= topLogPrefix + 'types.int8.write() - ';
+types = {
+	int8: {
+		read: function(buffer, offset) {
+			return buffer.readUInt8(offset);
+		},
+		write: function(value, buffer, offset) {
+			value = value || 0;
 
-		value	= value || 0;
+			try {
+				buffer.writeUInt8(value, offset);
+			} catch (err) {
+				log.error('larvitsmpp: lib/defs.js - Could not write integer value "' + value + '" on offset "' + offset + '" when buffer length is "' + buffer.length + '"');
+				throw err;
+			}
+		},
+		size: function() {
+			return 1;
+		},
+		default: 0
+	},
+	int16: {
+		read: function(buffer, offset) {
+			return buffer.readUInt16BE(offset);
+		},
+		write: function(value, buffer, offset) {
+			value = value || 0;
+			buffer.writeUInt16BE(value, offset);
+		},
+		size: function() {
+			return 2;
+		},
+		default: 0
+	},
+	int32: {
+		read: function(buffer, offset) {
+			return buffer.readUInt32BE(offset);
+		},
+		write: function(value, buffer, offset) {
+			value = value || 0;
+			buffer.writeUInt32BE(value, offset);
+		},
+		size: function() {
+			return 4;
+		},
+		default: 0
+	},
+	string: {
+		read: function(buffer, offset) {
+			var length = buffer.readUInt8(offset ++);
+			return buffer.toString('ascii', offset, offset + length);
+		},
+		write: function(value, buffer, offset) {
+			buffer.writeUInt8(value.length, offset ++);
+			if (typeof value === 'number') {
+				value = value.toString();
+			}
+			if (typeof value === 'string') {
+				value = new Buffer(value, 'ascii');
+			}
+			value.copy(buffer, offset);
+		},
+		size: function(value) {
+			if (typeof value === 'number') {
+				value = value.toString();
+			}
+			return value.length + 1;
+		},
+		default: ''
+	},
+	cstring: {
+		read: function(buffer, offset) {
+			var length = 0;
 
-		try {
-			buffer.writeUInt8(value, offset);
-		} catch (err) {
-			log.error(logPrefix + 'Could not write integer value "' + value + '" on offset "' + offset + '" when buffer length is "' + buffer.length + '"');
-			throw err;
-		}
-	},
-	'size': function size() {
-		return 1;
-	},
-	'default': 0
-};
+			// Increase length until the null-octet is found
+			while (buffer[offset + length]) {
+				length ++;
+			}
 
-types.int16 = {
-	'read': function read(buffer, offset) {
-		return buffer.readUInt16BE(offset);
-	},
-	'write': function write(value, buffer, offset) {
-		value = value || 0;
-		buffer.writeUInt16BE(value, offset);
-	},
-	'size': function size() {
-		return 2;
-	},
-	'default': 0
-};
+			return buffer.toString('ascii', offset, offset + length);
+		},
+		write: function(value, buffer, offset) {
+			if (typeof value === 'number') {
+				value = value.toString();
+			}
+			if (typeof value === 'string') {
+				value = new Buffer(value, 'ascii');
+			}
+			value.copy(buffer, offset);
+			buffer[offset + value.length] = 0;
+		},
+		size: function(value) {
+			if (typeof value === 'number') {
+				value = value.toString();
+			}
 
-types.int32 = {
-	'read': function read(buffer, offset) {
-		return buffer.readUInt32BE(offset);
+			return value.length + 1;
+		},
+		default: ''
 	},
-	'write': function write(value, buffer, offset) {
-		value = value || 0;
-		buffer.writeUInt32BE(value, offset);
+	buffer: {
+		read: function(buffer, offset, length) {
+			return buffer.slice(offset, offset + length);
+		},
+		write: function(value, buffer, offset) {
+			if (typeof value === 'number') {
+				value = value.toString();
+			}
+			if (typeof value === 'string') {
+				value = new Buffer(value, 'ascii');
+			}
+			value.copy(buffer, offset);
+		},
+		size: function(buffer) {
+			if (buffer[buffer.length - 1] === 0x00) {
+				return buffer.length - 1;
+			} else {
+				return buffer.length;
+			}
+		},
+		default: new Buffer(0)
 	},
-	'size': function size() {
-		return 4;
-	},
-	'default': 0
-};
+	dest_address_array: {
+		read: function(buffer, offset) {
+			var dest_address,
+			    dest_flag,
+			    result = [],
+			    number_of_dests = buffer.readUInt8(offset ++);
 
-types.string = {
-	'read': function read(buffer, offset) {
-		const	length	= buffer.readUInt8(offset ++);
-		return buffer.toString('ascii', offset, offset + length);
+			while (number_of_dests -- > 0) {
+				dest_flag = buffer.readUInt8(offset ++);
+				if (dest_flag === 1) {
+					dest_address = {
+						dest_addr_ton: buffer.readUInt8(offset ++),
+						dest_addr_npi: buffer.readUInt8(offset ++),
+						destination_addr: types.cstring.read(buffer, offset)
+					};
+					offset += types.cstring.size(dest_address.destination_addr);
+				} else {
+					dest_address = {
+						dl_name: types.cstring.read(buffer, offset)
+					};
+					offset += types.cstring.size(dest_address.dl_name);
+				}
+				result.push(dest_address);
+			}
+			return result;
+		},
+		write: function(value, buffer, offset) {
+			buffer.writeUInt8(value.length, offset ++);
+			value.forEach(function(dest_address) {
+				if ('dl_name' in dest_address) {
+					buffer.writeUInt8(2, offset ++);
+					types.cstring.write(dest_address.dl_name, buffer, offset);
+					offset += types.cstring.size(dest_address.dl_name);
+				} else {
+					buffer.writeUInt8(1, offset ++);
+					buffer.writeUInt8(dest_address.dest_addr_ton || 0, offset ++);
+					buffer.writeUInt8(dest_address.dest_addr_npi || 0, offset ++);
+					types.cstring.write(dest_address.destination_addr, buffer, offset);
+					offset += types.cstring.size(dest_address.destination_addr);
+				}
+			});
+		},
+		size: function(value) {
+			var size = 1;
+			value.forEach(function(dest_address) {
+				if ('dl_name' in dest_address) {
+					size += types.cstring.size(dest_address.dl_name) + 1;
+				} else {
+					size += types.cstring.size(dest_address.destination_addr) + 3;
+				}
+			});
+			return size;
+		},
+		default: []
 	},
-	'write': function write(value, buffer, offset) {
-		buffer.writeUInt8(value.length, offset ++);
-		if (typeof value === 'number') {
-			value = value.toString();
-		}
-		if (typeof value === 'string') {
-			value = new Buffer(value, 'ascii');
-		}
-		value.copy(buffer, offset);
-	},
-	'size': function size(value) {
-		if (typeof value === 'number') {
-			value = value.toString();
-		}
-		return value.length + 1;
-	},
-	'default': ''
-};
+	unsuccess_sme_array: {
+		read: function(buffer, offset) {
+			var unsuccess_sme,
+			    result       = [],
+			    no_unsuccess = buffer.readUInt8(offset ++);
 
-types.cstring = {
-	'read': function read(buffer, offset) {
-		let	length	= 0;
-
-		// Increase length until the null-octet is found
-		while (buffer[offset + length]) {
-			length ++;
-		}
-
-		return buffer.toString('ascii', offset, offset + length);
-	},
-	'write': function write(value, buffer, offset) {
-		if (typeof value === 'number') {
-			value = value.toString();
-		}
-		if (typeof value === 'string') {
-			value = new Buffer(value, 'ascii');
-		}
-		value.copy(buffer, offset);
-		buffer[offset + value.length] = 0;
-	},
-	'size': function size(value) {
-		if (typeof value === 'number') {
-			value = value.toString();
-		}
-
-		return value.length + 1;
-	},
-	'default': ''
-};
-
-types.buffer = {
-	'read': function read(buffer, offset, length) {
-		return buffer.slice(offset, offset + length);
-	},
-	'write': function write(value, buffer, offset) {
-		if (typeof value === 'number') {
-			value = value.toString();
-		}
-		if (typeof value === 'string') {
-			value = new Buffer(value, 'ascii');
-		}
-		value.copy(buffer, offset);
-	},
-	'size': function size(buffer) {
-		if (buffer[buffer.length - 1] === 0x00) {
-			return buffer.length - 1;
-		} else {
-			return buffer.length;
-		}
-	},
-	'default': new Buffer(0)
-};
-
-types.dest_address_array = {
-	'read': function read(buffer, offset) {
-		const	result	= [];
-
-		let	number_of_dests	= buffer.readUInt8(offset ++),
-			dest_address,
-			dest_flag;
-
-		while (number_of_dests -- > 0) {
-			dest_flag	= buffer.readUInt8(offset ++);
-			if (dest_flag === 1) {
-				dest_address = {
-					'dest_addr_ton':	buffer.readUInt8(offset ++),
-					'dest_addr_npi':	buffer.readUInt8(offset ++),
-					'destination_addr':	types.cstring.read(buffer, offset)
+			while (no_unsuccess -- > 0) {
+				unsuccess_sme = {
+					dest_addr_ton: buffer.readUInt8(offset ++),
+					dest_addr_npi: buffer.readUInt8(offset ++),
+					destination_addr: types.cstring.read(buffer, offset)
 				};
-				offset	+= types.cstring.size(dest_address.destination_addr);
-			} else {
-				dest_address = {
-					'dl_name':	types.cstring.read(buffer, offset)
-				};
-				offset	+= types.cstring.size(dest_address.dl_name);
+				offset += types.cstring.size(unsuccess_sme.destination_addr);
+				unsuccess_sme.error_status_code = buffer.readUInt32BE(offset);
+				offset += 4;
+				result.push(unsuccess_sme);
 			}
-			result.push(dest_address);
-		}
-		return result;
-	},
-	'write': function write(value, buffer, offset) {
-		buffer.writeUInt8(value.length, offset ++);
-		value.forEach(function (dest_address) {
-			if (Object.keys(dest_address).indexOf('dl_name') !== - 1) {
-				buffer.writeUInt8(2, offset ++);
-				types.cstring.write(dest_address.dl_name, buffer, offset);
-				offset	+= types.cstring.size(dest_address.dl_name);
-			} else {
-				buffer.writeUInt8(1,	offset ++);
-				buffer.writeUInt8(dest_address.dest_addr_ton || 0,	offset ++);
-				buffer.writeUInt8(dest_address.dest_addr_npi || 0,	offset ++);
-				types.cstring.write(dest_address.destination_addr, buffer, offset);
-				offset	+= types.cstring.size(dest_address.destination_addr);
-			}
-		});
-	},
-	'size': function size(value) {
-		let	size	= 1;
-		value.forEach(function (dest_address) {
-			if (Object.keys(dest_address).indexOf('dl_name') !== - 1) {
-				size	+= types.cstring.size(dest_address.dl_name) + 1;
-			} else {
-				size	+= types.cstring.size(dest_address.destination_addr) + 3;
-			}
-		});
-		return size;
-	},
-	'default': []
-};
-
-types.unsuccess_sme_array = {
-	'read': function read(buffer, offset) {
-		const	result	= [];
-
-		let	no_unsuccess	= buffer.readUInt8(offset ++);
-
-		while (no_unsuccess -- > 0) {
-			const unsuccess_sme = {
-				'dest_addr_ton':	buffer.readUInt8(offset ++),
-				'dest_addr_npi':	buffer.readUInt8(offset ++),
-				'destination_addr':	types.cstring.read(buffer, offset)
-			};
-			offset	+= types.cstring.size(unsuccess_sme.destination_addr);
-			unsuccess_sme.error_status_code	= buffer.readUInt32BE(offset);
-			offset	+= 4;
-			result.push(unsuccess_sme);
-		}
-		return result;
-	},
-	'write': function write(value, buffer, offset) {
-		buffer.writeUInt8(value.length, offset ++);
-		value.forEach(function (unsuccess_sme) {
-			buffer.writeUInt8(unsuccess_sme.dest_addr_ton || 0, offset ++);
-			buffer.writeUInt8(unsuccess_sme.dest_addr_npi || 0, offset ++);
-			types.cstring.write(unsuccess_sme.destination_addr, buffer, offset);
-			offset += types.cstring.size(unsuccess_sme.destination_addr);
-			buffer.writeUInt32BE(unsuccess_sme.error_status_code, offset);
-			offset += 4;
-		});
-	},
-	'size': function size(value) {
-		let	size	= 1;
-		value.forEach(function (unsuccess_sme) {
-			size += types.cstring.size(unsuccess_sme.destination_addr) + 6;
-		});
-		return size;
-	},
-	'default': []
+			return result;
+		},
+		write: function(value, buffer, offset) {
+			buffer.writeUInt8(value.length, offset ++);
+			value.forEach(function(unsuccess_sme) {
+				buffer.writeUInt8(unsuccess_sme.dest_addr_ton || 0, offset ++);
+				buffer.writeUInt8(unsuccess_sme.dest_addr_npi || 0, offset ++);
+				types.cstring.write(unsuccess_sme.destination_addr, buffer, offset);
+				offset += types.cstring.size(unsuccess_sme.destination_addr);
+				buffer.writeUInt32BE(unsuccess_sme.error_status_code, offset);
+				offset += 4;
+			});
+		},
+		size: function(value) {
+			var size = 1;
+			value.forEach(function(unsuccess_sme) {
+				size += types.cstring.size(unsuccess_sme.destination_addr) + 6;
+			});
+			return size;
+		},
+		default: []
+	}
 };
 
 types.tlv = {
-	'int8':	types.int8,
-	'int16':	types.int16,
-	'int32':	types.int32,
-	'cstring':	types.cstring,
-	'string': {
-		'read': function read(buffer, offset, length) {
+	int8: types.int8,
+	int16: types.int16,
+	int32: types.int32,
+	cstring: types.cstring,
+	string: {
+		read: function(buffer, offset, length) {
 			return buffer.toString('ascii', offset, offset + length);
 		},
-		'write': function write(value, buffer, offset) {
+		write: function(value, buffer, offset) {
 			if (typeof value === 'number') {
 				value = value.toString();
 			}
@@ -369,19 +365,19 @@ types.tlv = {
 			}
 			value.copy(buffer, offset);
 		},
-		'size': function size(value) {
+		size: function(value) {
 			if (typeof value === 'number') {
 				value = value.toString();
 			}
 			return value.length;
 		},
-		'default': ''
+		default: ''
 	},
-	'buffer': {
-		'read': function read(buffer, offset, length) {
+	buffer: {
+		read: function(buffer, offset, length) {
 			return buffer.slice(offset, offset + length);
 		},
-		'write': function write(value, buffer, offset) {
+		write: function(value, buffer, offset) {
 			if (typeof value === 'number') {
 				value = value.toString();
 			}
@@ -390,62 +386,65 @@ types.tlv = {
 			}
 			value.copy(buffer, offset);
 		},
-		'size': function size(value) {
+		size: function(value) {
 			if (typeof value === 'number') {
 				value = value.toString();
 			}
 			return value.length;
 		},
-		'default': null
+		default: null
 	}
 };
 
 encodings.ASCII = { // GSM 03.38
-	'chars':	'@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà',
-	'charCodes':	{},
-	'extChars':	{},
-	'regex':	/^[@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,\-./0-9:;<=>?¡A-ZÄÖÑÜ§¿a-zäöñüà\f^{}\\[~\]|€]*$/,
+	chars:     '@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà',
+	charCodes: {},
+	extChars:  {},
+	regex:     /^[@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,\-./0-9:;<=>?¡A-ZÄÖÑÜ§¿a-zäöñüà\f^{}\\[~\]|€]*$/,
 
-	'init': function init() {
-		const	from	= '\f^{}\\[~]|€',
-			to	= '\nΛ()/<=>¡e';
+	init: function() {
+		var from = '\f^{}\\[~]|€',
+		    to   = '\nΛ()/<=>¡e',
+		    i;
 
-		for (let i = 0; i < this.chars.length; i ++) {
+		for (i = 0; i < this.chars.length; i ++) {
 			this.charCodes[this.chars[i]] = i;
 		}
 
-		for (let i = 0; i < from.length; i ++) {
+		for (i = 0; i < from.length; i ++) {
 			this.extChars[from[i]] = to[i];
 			this.extChars[to[i]] = from[i];
 		}
 	},
 
-	'match': function match(value) {
+	match: function(value) {
 		return this.regex.test(value);
 	},
 
-	'encode': function encode(value) {
-		const	result	= [];
+	encode: function(value) {
+		var result = [],
+		    i;
 
-		value = value.replace(/[\f^{}\\[~\]|€]/g, function (match) {
+		value = value.replace(/[\f^{}\\[~\]|€]/g, function(match) {
 			return '\x1B' + this.extChars[match];
 		}.bind(this));
 
-		for (let i = 0; i < value.length; i ++) {
+		for (i = 0; i < value.length; i ++) {
 			result.push(value[i] in this.charCodes ? this.charCodes[value[i]] : 0x20);
 		}
 
 		return new Buffer(result);
 	},
 
-	'decode': function (value) {
-		let	result	= '';
+	decode: function(value) {
+		var result = '',
+		    i;
 
-		for (let i = 0; i < value.length; i ++) {
+		for (i = 0; i < value.length; i ++) {
 			result += this.chars[value[i]] || ' ';
 		}
 
-		result = result.replace(/\x1B([\nΛ()\/<=>¡e])/g, function (match, p1) {
+		result = result.replace(/\x1B([\nΛ()\/<=>¡e])/g, function(match, p1) {
 			return this.extChars[p1];
 		}.bind(this));
 
@@ -459,35 +458,37 @@ encodings.ASCII.init();
 
 encodings.LATIN1 = {
 	// Never use this for new messages
-	'match': function match() {
+	match: function() {
 		return false;
 	},
-	/*'match': function match(value) {
+	/*match: function(value) {
 		return value === iconv.decode(iconv.encode(value, 'latin1'), 'latin1');
 	},*/
-	'encode': function encode(value) {
+	encode: function(value) {
 		return iconv.encode(value, 'latin1');
 	},
-	'decode': function decode(value) {
+	decode: function(value) {
 		return iconv.decode(value, 'latin1');
 	}
 };
 
 encodings.UCS2 = {
-	'match': function match() {
+	match: function() {
 		return true;
 	},
-	'encode': function encode(value) {
+	encode: function(value) {
 		return iconv.encode(value, 'utf16-be');
 	},
-	'decode': function decode(value) {
+	decode: function(value) {
 		return iconv.decode(value, 'utf16-be');
 	}
 };
 
 Object.defineProperty(encodings, 'detect', {
-	'value': function value(value) {
-		for (const key in encodings) {
+	value: function(value) {
+		var key;
+
+		for (key in encodings) {
 			if (encodings[key].match(value)) {
 				return key;
 			}
@@ -498,8 +499,8 @@ Object.defineProperty(encodings, 'detect', {
 });
 
 filters.time = {
-	'encode': function encode(value) {
-		let	result;
+	encode: function(value) {
+		var result;
 
 		if ( ! value) {
 			return value;
@@ -507,21 +508,21 @@ filters.time = {
 
 		if (typeof value === 'string') {
 			if (value.length <= 12) {
-				value	= ('000000000000' + value).substr(- 12) + '000R';
+				value = ('000000000000' + value).substr(- 12) + '000R';
 			}
 
 			return value;
 		}
 
 		if (value instanceof Date) {
-			result	= value.getUTCFullYear().toString().substr(- 2);
-			result	+= ('0' + (value.getUTCMonth() + 1)).substr(- 2);
-			result	+= ('0' + value.getUTCDate()).substr(- 2);
-			result	+= ('0' + value.getUTCHours()).substr(- 2);
-			result	+= ('0' + value.getUTCMinutes()).substr(- 2);
-			result	+= ('0' + value.getUTCSeconds()).substr(- 2);
-			result	+= ('00' + value.getUTCMilliseconds()).substr(- 3, 1);
-			result	+= '00+';
+			result = value.getUTCFullYear().toString().substr(- 2);
+			result += ('0' + (value.getUTCMonth() + 1)).substr(- 2);
+			result += ('0' + value.getUTCDate()).substr(- 2);
+			result += ('0' + value.getUTCHours()).substr(- 2);
+			result += ('0' + value.getUTCMinutes()).substr(- 2);
+			result += ('0' + value.getUTCSeconds()).substr(- 2);
+			result += ('00' + value.getUTCMilliseconds()).substr(- 3, 1);
+			result += '00+';
 
 			return result;
 		}
@@ -529,23 +530,22 @@ filters.time = {
 		return value;
 	},
 
-	'decode': function decode(value) {
-		const	century	= ('000' + new Date().getUTCFullYear()).substr(- 4, 2);
-
-		let	result	= new Date(value.replace(/^(..)(..)(..)(..)(..)(..)(.)?.*$/, century + '$1-$2-$3 $4:$5:$6:$700 UTC')),
-			match   = value.match(/(..)([-+])$/),
-			diff;
+	decode: function(value) {
+		var century = ('000' + new Date().getUTCFullYear()).substr(- 4, 2),
+		    result  = new Date(value.replace(/^(..)(..)(..)(..)(..)(..)(.)?.*$/, century + '$1-$2-$3 $4:$5:$6:$700 UTC')),
+		    match   = value.match(/(..)([-+])$/),
+		    diff;
 
 		if ( ! value || typeof value !== 'string') {
 			return value;
 		}
 
 		if (value.substr(- 1) === 'R') {
-			result	= new Date();
-			match	= value.match(/^(..)(..)(..)(..)(..)(..).*$/);
+			result = new Date();
+			match  = value.match(/^(..)(..)(..)(..)(..)(..).*$/);
 
 			['FullYear', 'Month', 'Date', 'Hours', 'Minutes', 'Seconds'].forEach(
-				function (method, i) {
+				function(method, i) {
 					result['set' + method](result['get' + method]() + + match[++ i]);
 				}
 			);
@@ -566,9 +566,9 @@ filters.time = {
 };
 
 filters.message = {
-	'encode': function encode(value) {
-		let	message	= typeof value === 'string' ? value : value.message,
-			encoding	= encodings.detect(message);
+	encode: function(value) {
+		var message  = typeof value === 'string' ? value : value.message,
+		    encoding = encodings.detect(message);
 
 		if (Buffer.isBuffer(value)) {
 			return value;
@@ -579,49 +579,48 @@ filters.message = {
 				this.data_coding = consts.ENCODING[encoding];
 			}
 
-			message	= encodings[encoding].encode(message);
+			message = encodings[encoding].encode(message);
 		}
 
 		if ( ! value.udh || ! value.udh.length) {
 			return message;
 		}
 
-		this.esm_class	= this.esm_class | consts.ESM_CLASS.UDH_INDICATOR;
+		this.esm_class = this.esm_class | consts.ESM_CLASS.UDH_INDICATOR;
 
 		return Buffer.concat([value.udh, message]);
 	},
 
-	'decode': function decode(value) {
-		const	result	= {};
-
-		let	encoding	= this.data_coding & 0x0F,
-			udhi	= this.esm_class & consts.ESM_CLASS.UDH_INDICATOR,
-			key;
+	decode: function(value) {
+		var encoding = this.data_coding & 0x0F,
+		    udhi     = this.esm_class & consts.ESM_CLASS.UDH_INDICATOR,
+		    result   = {},
+		    key;
 
 		if ( ! Buffer.isBuffer(value)) {
 			return value;
 		}
 
 		if ( ! encoding) {
-			encoding	= 'ASCII';
+			encoding = 'ASCII';
 		} else {
 			for (key in consts.ENCODING) {
 				if (consts.ENCODING[key] === encoding) {
-					encoding	= key;
+					encoding = key;
 					break;
 				}
 			}
 		}
 
 		if (value.length && udhi) {
-			result.udh	= value.slice(0, value[0] + 1);
-			result.message	= value.slice(value[0] + 1);
+			result.udh     = value.slice(0, value[0] + 1);
+			result.message = value.slice(value[0] + 1);
 		} else {
-			result.message	= value;
+			result.message = value;
 		}
 
 		if (encodings[encoding]) {
-			result.message	= encodings[encoding].decode(result.message);
+			result.message = encodings[encoding].decode(result.message);
 		}
 
 		return result;
@@ -629,8 +628,8 @@ filters.message = {
 };
 
 filters.billing_identification = {
-	'encode': function encode(value) {
-		let	result	= new Buffer(value.data.length + 1);
+	encode: function(value) {
+		var result = new Buffer(value.data.length + 1);
 
 		if (Buffer.isBuffer(value)) {
 			return value;
@@ -642,21 +641,21 @@ filters.billing_identification = {
 		return result;
 	},
 
-	'decode': function decode(value) {
+	decode: function(value) {
 		if ( ! Buffer.isBuffer(value)) {
 			return value;
 		}
 
 		return {
-			'format':	value.readUInt8(0),
-			'data':	value.slice(1)
+			format: value.readUInt8(0),
+			data: value.slice(1)
 		};
 	}
 };
 
 filters.broadcast_area_identifier = {
-	'encode': function encode(value) {
-		let	result	= new Buffer(value.data.length + 1);
+	encode: function(value) {
+		var result = new Buffer(value.data.length + 1);
 
 		if (Buffer.isBuffer(value)) {
 			return value;
@@ -664,13 +663,13 @@ filters.broadcast_area_identifier = {
 
 		if (typeof value === 'string') {
 			value = {
-				'format':	consts.BROADCAST_AREA_FORMAT.NAME,
-				'data':	value
+				format: consts.BROADCAST_AREA_FORMAT.NAME,
+				data: value
 			};
 		}
 
 		if (typeof value.data === 'string') {
-			value.data	= new Buffer(value.data, 'ascii');
+			value.data = new Buffer(value.data, 'ascii');
 		}
 
 		result.writeUInt8(value.format, 0);
@@ -679,10 +678,10 @@ filters.broadcast_area_identifier = {
 		return result;
 	},
 
-	'decode': function decode(value) {
-		const result = {
-			'format':	value.readUInt8(0),
-			'data':	value.slice(1)
+	decode: function(value) {
+		var result = {
+			format: value.readUInt8(0),
+			data: value.slice(1)
 		};
 
 		if ( ! Buffer.isBuffer(value)) {
@@ -698,8 +697,8 @@ filters.broadcast_area_identifier = {
 };
 
 filters.broadcast_content_type = {
-	'encode': function encode(value) {
-		let	result	= new Buffer(3);
+	encode: function(value) {
+		var result = new Buffer(3);
 
 		if (Buffer.isBuffer(value)) {
 			return value;
@@ -711,21 +710,21 @@ filters.broadcast_content_type = {
 		return result;
 	},
 
-	'decode': function decode(value) {
+	decode: function(value) {
 		if ( ! Buffer.isBuffer(value)) {
 			return value;
 		}
 
 		return {
-			'network':	value.readUInt8(0),
-			'content_type':	value.readUInt16BE(1)
+			network: value.readUInt8(0),
+			content_type: value.readUInt16BE(1)
 		};
 	}
 };
 
 filters.broadcast_frequency_interval = {
-	'encode': function encode(value) {
-		let	result	= new Buffer(3);
+	encode: function(value) {
+		var result = new Buffer(3);
 
 		if (Buffer.isBuffer(value)) {
 			return value;
@@ -737,21 +736,21 @@ filters.broadcast_frequency_interval = {
 		return result;
 	},
 
-	'decode': function decode(value) {
+	decode: function(value) {
 		if ( ! Buffer.isBuffer(value)) {
 			return value;
 		}
 
 		return {
-			'unit':	value.readUInt8(0),
-			'interval':	value.readUInt16BE(1)
+			unit: value.readUInt8(0),
+			interval: value.readUInt16BE(1)
 		};
 	}
 };
 
 filters.callback_num = {
-	'encode': function encode(value) {
-		let	result	= new Buffer(value.number.length + 3);
+	encode: function(value) {
+		var result = new Buffer(value.number.length + 3);
 
 		if (Buffer.isBuffer(value)) {
 			return value;
@@ -764,23 +763,23 @@ filters.callback_num = {
 
 		return result;
 	},
-	'decode': function decode(value) {
+	decode: function(value) {
 		if ( ! Buffer.isBuffer(value)) {
 			return value;
 		}
 
 		return {
-			'digit_mode':	value.readUInt8(0),
-			'ton':	value.readUInt8(1),
-			'npi':	value.readUInt8(2),
-			'number':	value.toString('ascii', 3)
+			digit_mode: value.readUInt8(0),
+			ton: value.readUInt8(1),
+			npi: value.readUInt8(2),
+			number: value.toString('ascii', 3)
 		};
 	}
 };
 
 filters.callback_num_atag = {
-	'encode': function encode(value) {
-		let	result	= new Buffer(value.display.length + 1);
+	encode: function(value) {
+		var result = new Buffer(value.display.length + 1);
 
 		if (Buffer.isBuffer(value)) {
 			return value;
@@ -797,676 +796,686 @@ filters.callback_num_atag = {
 		return result;
 	},
 
-	'decode': function decode(value) {
+	decode: function(value) {
 		if ( ! Buffer.isBuffer(value)) {
 			return value;
 		}
 
 		return {
-			'encoding':	value.readUInt8(0),
-			'display':	value.slice(1)
+			encoding: value.readUInt8(0),
+			display: value.slice(1)
 		};
 	}
 };
 
-tlvs.default = {
-	'id':	undefined,
-	'type':	types.tlv.buffer
-};
-tlvs.dest_addr_subunit = {
-	'id':	0x0005,
-	'type':	types.tlv.int8
-};
-tlvs.dest_network_type = {
-	'id':	0x0006,
-	'type':	types.tlv.int8
-};
-tlvs.dest_bearer_type = {
-	'id':	0x0007,
-	'type':	types.tlv.int8
-};
-tlvs.dest_telematics_id = {
-	'id':	0x0008,
-	'type':	types.tlv.int16
-};
-tlvs.source_addr_subunit = {
-	'id':	0x000D,
-	'type':	types.tlv.int8
-};
-tlvs.source_network_type = {
-	'id':	0x000E,
-	'type':	types.tlv.int8
-};
-tlvs.source_bearer_type = {
-	'id':	0x000F,
-	'type':	types.tlv.int8
-};
-tlvs.source_telematics_id = {
-	'id':	0x0010,
-	'type':	types.tlv.int16
-};
-tlvs.qos_time_to_live = {
-	'id':	0x0017,
-	'type':	types.tlv.int32
-};
-tlvs.payload_type = {
-	'id':	0x0019,
-	'type':	types.tlv.int8
-};
-tlvs.additional_status_info_text = {
-	'id':	0x001D,
-	'type':	types.tlv.cstring
-};
-tlvs.receipted_message_id = {
-	'id':	0x001E,
-	'type':	types.tlv.cstring
-};
-tlvs.ms_msg_wait_facilities = {
-	'id':	0x0030,
-	'type':	types.tlv.int8
-};
-tlvs.privacy_indicator = {
-	'id':	0x0201,
-	'type':	types.tlv.int8
-};
-tlvs.source_subaddress = {
-	'id':	0x0202,
-	'type':	types.tlv.buffer
-};
-tlvs.dest_subaddress = {
-	'id':	0x0203,
-	'type':	types.tlv.buffer
-};
-tlvs.user_message_reference = {
-	'id':	0x0204,
-	'type':	types.tlv.int16
-};
-tlvs.user_response_code = {
-	'id':	0x0205,
-	'type':	types.tlv.int8
-};
-tlvs.source_port = {
-	'id':	0x020A,
-	'type':	types.tlv.int16
-};
-tlvs.dest_port = {
-	'id':	0x020B,
-	'type':	types.tlv.int16
-};
-tlvs.sar_msg_ref_num = {
-	'id':	0x020C,
-	'type':	types.tlv.int16
-};
-tlvs.language_indicator = {
-	'id':	0x020D,
-	'type':	types.tlv.int8
-};
-tlvs.sar_total_segments = {
-	'id':	0x020E,
-	'type':	types.tlv.int8
-};
-tlvs.sar_segment_seqnum = {
-	'id':	0x020F,
-	'type':	types.tlv.int8
-};
-tlvs.sc_interface_version = {
-	'id':	0x0210,
-	'type':	types.tlv.int8
-};
-tlvs.callback_num_pres_ind = {
-	'id':	0x0302,
-	'type':	types.tlv.int8,
-	'multiple':	true
-};
-tlvs.callback_num_atag = {
-	'id':	0x0303,
-	'type':	types.tlv.buffer,
-	'filter':	filters.callback_num_atag,
-	'multiple':	true
-};
-tlvs.number_of_messages = {
-	'id':	0x0304,
-	'type':	types.tlv.int8
-};
-tlvs.callback_num = {
-	'id':	0x0381,
-	'type':	types.tlv.buffer,
-	'filter':	filters.callback_num,
-	'multiple':	true
-};
-tlvs.dpf_result = {
-	'id':	0x0420,
-	'type':	types.tlv.int8
-};
-tlvs.set_dpf = {
-	'id':	0x0421,
-	'type':	types.tlv.int8
-};
-tlvs.ms_availability_status = {
-	'id':	0x0422,
-	'type':	types.tlv.int8
-};
-tlvs.network_error_code = {
-	'id':	0x0423,
-	'type':	types.tlv.buffer
-};
-tlvs.message_payload = {
-	'id':	0x0424,
-	'type':	types.tlv.buffer,
-	'filter':	filters.message
-};
-tlvs.delivery_failure_reason = {
-	'id':	0x0425,
-	'type':	types.tlv.int8
-};
-tlvs.more_messages_to_send = {
-	'id':	0x0426,
-	'type':	types.tlv.int8
-};
-tlvs.message_state = {
-	'id':	0x0427,
-	'type':	types.tlv.int8
-};
-tlvs.congestion_state = {
-	'id':	0x0428,
-	'type':	types.tlv.int8
-};
-tlvs.ussd_service_op = {
-	'id':	0x0501,
-	'type':	types.tlv.int8
-};
-tlvs.broadcast_channel_indicator = {
-	'id':	0x0600,
-	'type':	types.tlv.int8
-};
-tlvs.broadcast_content_type = {
-	'id':	0x0601,
-	'type':	types.tlv.buffer,
-	'filter':	filters.broadcast_content_type
-};
-tlvs.broadcast_content_type_info = {
-	'id':	0x0602,
-	'type':	types.tlv.string
-};
-tlvs.broadcast_message_class = {
-	'id':	0x0603,
-	'type':	types.tlv.int8
-};
-tlvs.broadcast_rep_num = {
-	'id':	0x0604,
-	'type':	types.tlv.int16
-};
-tlvs.broadcast_frequency_interval = {
-	'id':	0x0605,
-	'type':	types.tlv.buffer,
-	'filter':	filters.broadcast_frequency_interval
-};
-tlvs.broadcast_area_identifier = {
-	'id':	0x0606,
-	'type':	types.tlv.buffer,
-	'filter':	filters.broadcast_area_identifier,
-	'multiple':	true
-};
-tlvs.broadcast_error_status = {
-	'id':	0x0607,
-	'type':	types.tlv.int32,
-	'multiple':	true
-};
-tlvs.broadcast_area_success = {
-	'id':	0x0608,
-	'type':	types.tlv.int8
-};
-tlvs.broadcast_end_time = {
-	'id':	0x0609,
-	'type':	types.tlv.string,
-	'filter':	filters.time
-};
-tlvs.broadcast_service_group = {
-	'id':	0x060A,
-	'type':	types.tlv.string
-};
-tlvs.billing_identification = {
-	'id':	0x060B,
-	'type':	types.tlv.buffer,
-	'filter':	filters.billing_identification
-};
-tlvs.source_network_id = {
-	'id':	0x060D,
-	'type':	types.tlv.cstring
-};
-tlvs.dest_network_id = {
-	'id':	0x060E,
-	'type':	types.tlv.cstring
-};
-tlvs.source_node_id = {
-	'id':	0x060F,
-	'type':	types.tlv.string
-};
-tlvs.dest_node_id = {
-	'id':	0x0610,
-	'type':	types.tlv.string
-};
-tlvs.dest_addr_np_resolution = {
-	'id':	0x0611,
-	'type':	types.tlv.int8
-};
-tlvs.dest_addr_np_information = {
-	'id':	0x0612,
-	'type':	types.tlv.string
-};
-tlvs.dest_addr_np_country = {
-	'id':	0x0613,
-	'type':	types.tlv.int32
-};
-tlvs.display_time = {
-	'id':	0x1201,
-	'type':	types.tlv.int8
-};
-tlvs.sms_signal = {
-	'id':	0x1203,
-	'type':	types.tlv.int16
-};
-tlvs.ms_validity = {
-	'id':	0x1204,
-	'type':	types.tlv.buffer
-};
-tlvs.alert_on_message_delivery = {
-	'id':	0x130C,
-	'type':	types.tlv.int8
-};
-tlvs.its_reply_type = {
-	'id':	0x1380,
-	'type':	types.tlv.int8
-};
-tlvs.its_session_info = {
-	'id':	0x1383,
-	'type':	types.tlv.buffer
-};
-
-for (const tag in tlvs) {
-	tlvsById[tlvs[tag].id]	= tlvs[tag];
-	tlvs[tag].tag	= tag;
-}
-
-tlvs.alert_on_msg_delivery	= tlvs.alert_on_message_delivery;
-tlvs.failed_broadcast_area_identifier	= tlvs.broadcast_area_identifier;
-
-cmds.alert_notification = {
-	'id':	0x00000102,
-	'params': {
-		'source_addr_ton':	{type: types.int8},
-		'source_addr_npi':	{type: types.int8},
-		'source_addr':	{type: types.cstring},
-		'esme_addr_ton':	{type: types.int8},
-		'esme_addr_npi':	{type: types.int8},
-		'esme_addr':	{type: types.cstring}
-	}
-};
-cmds.bind_receiver = {
-	'id':	0x00000001,
-	'params': {
-		'system_id':	{type: types.cstring},
-		'password':	{type: types.cstring},
-		'system_type':	{type: types.cstring},
-		'interface_version':	{type: types.int8, 'default': 0x50},
-		'addr_ton':	{type: types.int8},
-		'addr_npi':	{type: types.int8},
-		'address_range':	{type: types.cstring}
-	}
-};
-cmds.bind_receiver_resp = {
-	'id':	0x80000001,
-	'params': {
-		'system_id':	{type: types.cstring}
-	}
-};
-cmds.bind_transmitter = {
-	'id':	0x00000002,
-	'params': {
-		'system_id':	{type: types.cstring},
-		'password':	{type: types.cstring},
-		'system_type':	{type: types.cstring},
-		'interface_version':	{type: types.int8, 'default': 0x50},
-		'addr_ton':	{type: types.int8},
-		'addr_npi':	{type: types.int8},
-		'address_range':	{type: types.cstring}
-	}
-};
-cmds.bind_transmitter_resp = {
-	'id':	0x80000002,
-	'params': {
-		'system_id':	{type: types.cstring}
-	}
-};
-cmds.bind_transceiver = {
-	'id':	0x00000009,
-	'params': {
-		'system_id':	{type: types.cstring},
-		'password':	{type: types.cstring},
-		'system_type':	{type: types.cstring},
-		'interface_version':	{type: types.int8, 'default': 0x50},
-		'addr_ton':	{type: types.int8},
-		'addr_npi':	{type: types.int8},
-		'address_range':	{type: types.cstring}
-	}
-};
-cmds.bind_transceiver_resp = {
-	'id':	0x80000009,
-	'params': {
-		'system_id': {type: types.cstring}
-	}
-};
-cmds.broadcast_sm = {
-	'id':	0x00000111,
-	'params': {
-		'service_type':	{type: types.cstring},
-		'source_addr_ton':	{type: types.int8},
-		'source_addr_npi':	{type: types.int8},
-		'source_addr':	{type: types.cstring},
-		'message_id':	{type: types.cstring},
-		'priority_flag':	{type: types.int8},
-		'schedule_delivery_time':	{type: types.cstring, filter: filters.time},
-		'validity_period':	{type: types.cstring, filter: filters.time},
-		'replace_if_present_flag':	{type: types.int8},
-		'data_coding':	{type: types.int8},
-		'sm_default_msg_id':	{type: types.int8}
-	}
-};
-cmds.broadcast_sm_resp = {
-	'id':	0x80000111,
-	'params': {
-		'message_id':	{type: types.cstring}
+tlvs = {
+	default: {
+		id: undefined,
+		type: types.tlv.buffer
 	},
-	'tlvMap': {
-		'broadcast_area_identifier':	'failed_broadcast_area_identifier'
+	dest_addr_subunit: {
+		id: 0x0005,
+		type: types.tlv.int8
+	},
+	dest_network_type: {
+		id: 0x0006,
+		type: types.tlv.int8
+	},
+	dest_bearer_type: {
+		id: 0x0007,
+		type: types.tlv.int8
+	},
+	dest_telematics_id: {
+		id: 0x0008,
+		type: types.tlv.int16
+	},
+	source_addr_subunit: {
+		id: 0x000D,
+		type: types.tlv.int8
+	},
+	source_network_type: {
+		id: 0x000E,
+		type: types.tlv.int8
+	},
+	source_bearer_type: {
+		id: 0x000F,
+		type: types.tlv.int8
+	},
+	source_telematics_id: {
+		id: 0x0010,
+		type: types.tlv.int16
+	},
+	qos_time_to_live: {
+		id: 0x0017,
+		type: types.tlv.int32
+	},
+	payload_type: {
+		id: 0x0019,
+		type: types.tlv.int8
+	},
+	additional_status_info_text: {
+		id: 0x001D,
+		type: types.tlv.cstring
+	},
+	receipted_message_id: {
+		id: 0x001E,
+		type: types.tlv.cstring
+	},
+	ms_msg_wait_facilities: {
+		id: 0x0030,
+		type: types.tlv.int8
+	},
+	privacy_indicator: {
+		id: 0x0201,
+		type: types.tlv.int8
+	},
+	source_subaddress: {
+		id: 0x0202,
+		type: types.tlv.buffer
+	},
+	dest_subaddress: {
+		id: 0x0203,
+		type: types.tlv.buffer
+	},
+	user_message_reference: {
+		id: 0x0204,
+		type: types.tlv.int16
+	},
+	user_response_code: {
+		id: 0x0205,
+		type: types.tlv.int8
+	},
+	source_port: {
+		id: 0x020A,
+		type: types.tlv.int16
+	},
+	dest_port: {
+		id: 0x020B,
+		type: types.tlv.int16
+	},
+	sar_msg_ref_num: {
+		id: 0x020C,
+		type: types.tlv.int16
+	},
+	language_indicator: {
+		id: 0x020D,
+		type: types.tlv.int8
+	},
+	sar_total_segments: {
+		id: 0x020E,
+		type: types.tlv.int8
+	},
+	sar_segment_seqnum: {
+		id: 0x020F,
+		type: types.tlv.int8
+	},
+	sc_interface_version: {
+		id: 0x0210,
+		type: types.tlv.int8
+	},
+	callback_num_pres_ind: {
+		id: 0x0302,
+		type: types.tlv.int8,
+		multiple: true
+	},
+	callback_num_atag: {
+		id: 0x0303,
+		type: types.tlv.buffer,
+		filter: filters.callback_num_atag,
+		multiple: true
+	},
+	number_of_messages: {
+		id: 0x0304,
+		type: types.tlv.int8
+	},
+	callback_num: {
+		id: 0x0381,
+		type: types.tlv.buffer,
+		filter: filters.callback_num,
+		multiple: true
+	},
+	dpf_result: {
+		id: 0x0420,
+		type: types.tlv.int8
+	},
+	set_dpf: {
+		id: 0x0421,
+		type: types.tlv.int8
+	},
+	ms_availability_status: {
+		id: 0x0422,
+		type: types.tlv.int8
+	},
+	network_error_code: {
+		id: 0x0423,
+		type: types.tlv.buffer
+	},
+	message_payload: {
+		id: 0x0424,
+		type: types.tlv.buffer,
+		filter: filters.message
+	},
+	delivery_failure_reason: {
+		id: 0x0425,
+		type: types.tlv.int8
+	},
+	more_messages_to_send: {
+		id: 0x0426,
+		type: types.tlv.int8
+	},
+	message_state: {
+		id: 0x0427,
+		type: types.tlv.int8
+	},
+	congestion_state: {
+		id: 0x0428,
+		type: types.tlv.int8
+	},
+	ussd_service_op: {
+		id: 0x0501,
+		type: types.tlv.int8
+	},
+	broadcast_channel_indicator: {
+		id: 0x0600,
+		type: types.tlv.int8
+	},
+	broadcast_content_type: {
+		id: 0x0601,
+		type: types.tlv.buffer,
+		filter: filters.broadcast_content_type
+	},
+	broadcast_content_type_info: {
+		id: 0x0602,
+		type: types.tlv.string
+	},
+	broadcast_message_class: {
+		id: 0x0603,
+		type: types.tlv.int8
+	},
+	broadcast_rep_num: {
+		id: 0x0604,
+		type: types.tlv.int16
+	},
+	broadcast_frequency_interval: {
+		id: 0x0605,
+		type: types.tlv.buffer,
+		filter: filters.broadcast_frequency_interval
+	},
+	broadcast_area_identifier: {
+		id: 0x0606,
+		type: types.tlv.buffer,
+		filter: filters.broadcast_area_identifier,
+		multiple: true
+	},
+	broadcast_error_status: {
+		id: 0x0607,
+		type: types.tlv.int32,
+		multiple: true
+	},
+	broadcast_area_success: {
+		id: 0x0608,
+		type: types.tlv.int8
+	},
+	broadcast_end_time: {
+		id: 0x0609,
+		type: types.tlv.string,
+		filter: filters.time
+	},
+	broadcast_service_group: {
+		id: 0x060A,
+		type: types.tlv.string
+	},
+	billing_identification: {
+		id: 0x060B,
+		type: types.tlv.buffer,
+		filter: filters.billing_identification
+	},
+	source_network_id: {
+		id: 0x060D,
+		type: types.tlv.cstring
+	},
+	dest_network_id: {
+		id: 0x060E,
+		type: types.tlv.cstring
+	},
+	source_node_id: {
+		id: 0x060F,
+		type: types.tlv.string
+	},
+	dest_node_id: {
+		id: 0x0610,
+		type: types.tlv.string
+	},
+	dest_addr_np_resolution: {
+		id: 0x0611,
+		type: types.tlv.int8
+	},
+	dest_addr_np_information: {
+		id: 0x0612,
+		type: types.tlv.string
+	},
+	dest_addr_np_country: {
+		id: 0x0613,
+		type: types.tlv.int32
+	},
+	display_time: {
+		id: 0x1201,
+		type: types.tlv.int8
+	},
+	sms_signal: {
+		id: 0x1203,
+		type: types.tlv.int16
+	},
+	ms_validity: {
+		id: 0x1204,
+		type: types.tlv.buffer
+	},
+	alert_on_message_delivery: {
+		id: 0x130C,
+		type: types.tlv.int8
+	},
+	its_reply_type: {
+		id: 0x1380,
+		type: types.tlv.int8
+	},
+	its_session_info: {
+		id: 0x1383,
+		type: types.tlv.buffer
 	}
-};
-cmds.cancel_broadcast_sm = {
-	'id':	0x00000113,
-	'params': {
-		'service_type':	{type: types.cstring},
-		'message_id':	{type: types.cstring},
-		'source_addr_ton':	{type: types.int8},
-		'source_addr_npi':	{type: types.int8},
-		'source_addr':	{type: types.cstring}
-	}
-};
-cmds.cancel_broadcast_sm_resp = {
-	'id':	0x80000113
-};
-cmds.cancel_sm = {
-	'id':	0x00000008,
-	'params': {
-		'service_type':	{type: types.cstring},
-		'message_id':	{type: types.cstring},
-		'source_addr_ton':	{type: types.int8},
-		'source_addr_npi':	{type: types.int8},
-		'source_addr':	{type: types.cstring},
-		'dest_addr_ton':	{type: types.int8},
-		'dest_addr_npi':	{type: types.int8},
-		'destination_addr':	{type: types.cstring}
-	}
-};
-cmds.cancel_sm_resp = {
-	'id':	0x80000008
-};
-cmds.data_sm = {
-	'id':	0x00000103,
-	'params': {
-		'service_type':	{type: types.cstring},
-		'source_addr_ton':	{type: types.int8},
-		'source_addr_npi':	{type: types.int8},
-		'source_addr':	{type: types.cstring},
-		'dest_addr_ton':	{type: types.int8},
-		'dest_addr_npi':	{type: types.int8},
-		'destination_addr':	{type: types.cstring},
-		'esm_class':	{type: types.int8},
-		'registered_delivery':	{type: types.int8},
-		'data_coding':	{type: types.int8}
-	}
-};
-cmds.data_sm_resp = {
-	'id':	0x80000103,
-	'params': {
-		'message_id':	{type: types.cstring}
-	}
-};
-cmds.deliver_sm = {
-	'id':	0x00000005,
-	'params': {
-		'service_type':	{type: types.cstring},
-		'source_addr_ton':	{type: types.int8},
-		'source_addr_npi':	{type: types.int8},
-		'source_addr':	{type: types.cstring},
-		'dest_addr_ton':	{type: types.int8},
-		'dest_addr_npi':	{type: types.int8},
-		'destination_addr':	{type: types.cstring},
-		'esm_class':	{type: types.int8},
-		'protocol_id':	{type: types.int8},
-		'priority_flag':	{type: types.int8},
-		'schedule_delivery_time':	{type: types.cstring, filter: filters.time},
-		'validity_period':	{type: types.cstring, filter: filters.time},
-		'registered_delivery':	{type: types.int8},
-		'replace_if_present_flag':	{type: types.int8},
-		'data_coding':	{type: types.int8},
-		'sm_default_msg_id':	{type: types.int8},
-		'sm_length':	{type: types.int8},
-		'short_message':	{type: types.buffer, filter: filters.message}
-	}
-};
-cmds.deliver_sm_resp = {
-	'id':	0x80000005,
-	'params': {
-		'message_id':	{type: types.cstring}
-	}
-};
-cmds.enquire_link = {
-	'id':	0x00000015
-};
-cmds.enquire_link_resp = {
-	'id':	0x80000015
-};
-cmds.generic_nack = {
-	'id':	0x80000000
-};
-cmds.outbind = {
-	'id':	0x0000000B,
-	'params': {
-		'system_id':	{type: types.cstring},
-		'password':	{type: types.cstring}
-	}
-};
-cmds.query_broadcast_sm = {
-	'id':	0x00000112,
-	'params': {
-		'message_id':	{type: types.cstring},
-		'source_addr_ton':	{type: types.int8},
-		'source_addr_npi':	{type: types.int8},
-		'source_addr':	{type: types.cstring}
-	}
-};
-cmds.query_broadcast_sm_resp = {
-	'id':	0x80000112,
-	'params': {
-		'message_id':	{type: types.cstring}
-	}
-};
-cmds.query_sm = {
-	'id':	0x00000003,
-	'params': {
-		'message_id':	{type: types.cstring},
-		'source_addr_ton':	{type: types.int8},
-		'source_addr_npi':	{type: types.int8},
-		'source_addr':	{type: types.cstring}
-	}
-};
-cmds.query_sm_resp = {
-	'id':	0x80000003,
-	'params': {
-		'message_id':	{type: types.cstring},
-		'final_date':	{type: types.cstring, filter: filters.time},
-		'message_state':	{type: types.int8},
-		'error_code':	{type: types.int8}
-	}
-};
-cmds.replace_sm = {
-	'id':	0x00000007,
-	'params': {
-		'message_id':	{type: types.cstring},
-		'source_addr_ton':	{type: types.int8},
-		'source_addr_npi':	{type: types.int8},
-		'source_addr':	{type: types.cstring},
-		'schedule_delivery_time':	{type: types.cstring, filter: filters.time},
-		'validity_period':	{type: types.cstring, filter: filters.time},
-		'registered_delivery':	{type: types.int8},
-		'sm_default_msg_id':	{type: types.int8},
-		'sm_length':	{type: types.int8},
-		'short_message':	{type: types.buffer, filter: filters.message}
-	}
-};
-cmds.replace_sm_resp = {
-	'id':	0x80000007
-};
-cmds.submit_multi = {
-	'id':	0x00000021,
-	'params': {
-		'service_type':	{type: types.cstring},
-		'source_addr_ton':	{type: types.int8},
-		'source_addr_npi':	{type: types.int8},
-		'source_addr':	{type: types.cstring},
-		//'number_of_dests':	{type: types.int8},
-		'dest_address':	{type: types.dest_address_array},
-		'esm_class':	{type: types.int8},
-		'protocol_id':	{type: types.int8},
-		'priority_flag':	{type: types.int8},
-		'schedule_delivery_time':	{type: types.cstring, filter: filters.time},
-		'validity_period':	{type: types.cstring, filter: filters.time},
-		'registered_delivery':	{type: types.int8},
-		'replace_if_present_flag':	{type: types.int8},
-		'data_coding':	{type: types.int8},
-		'sm_default_msg_id':	{type: types.int8},
-		//'sm_length':	{type: types.int8},
-		'short_message':	{type: types.buffer, filter: filters.message}
-	}
-};
-cmds.submit_multi_resp = {
-	'id':	0x80000021,
-	'params': {
-		'message_id':	{type: types.cstring},
-		//'no_unsuccess':	{type: types.int8},
-		'unsuccess_sme':	{type: types.unsuccess_sme_array}
-	}
-};
-cmds.submit_sm = {
-	'id':	0x00000004,
-	'params': {
-		'service_type':	{type: types.cstring},
-		'source_addr_ton':	{type: types.int8},
-		'source_addr_npi':	{type: types.int8},
-		'source_addr':	{type: types.cstring},
-		'dest_addr_ton':	{type: types.int8},
-		'dest_addr_npi':	{type: types.int8},
-		'destination_addr':	{type: types.cstring},
-		'esm_class':	{type: types.int8},
-		'protocol_id':	{type: types.int8},
-		'priority_flag':	{type: types.int8},
-		'schedule_delivery_time':	{type: types.cstring, filter: filters.time},
-		'validity_period':	{type: types.cstring, filter: filters.time},
-		'registered_delivery':	{type: types.int8},
-		'replace_if_present_flag':	{type: types.int8},
-		'data_coding':	{type: types.int8},
-		'sm_default_msg_id':	{type: types.int8},
-		'sm_length':	{type: types.int8},
-		'short_message':	{type: types.buffer, filter: filters.message}
-	}
-};
-cmds.submit_sm_resp = {
-	'id':	0x80000004,
-	'params': {
-		'message_id': {type: types.cstring}
-	}
-};
-cmds.unbind = {
-	'id':	0x00000006
-};
-cmds.unbind_resp = {
-	'id':	0x80000006
 };
 
-for (const command in cmds) {
-	cmdsById[cmds[command].id]	= cmds[command];
-	cmds[command].command	= command;
+for (tag in tlvs) {
+	tlvsById[tlvs[tag].id] = tlvs[tag];
+	tlvs[tag].tag = tag;
 }
 
-errors.ESME_ROK	= 0x0000;
-errors.ESME_RINVMSGLEN	= 0x0001;
-errors.ESME_RINVCMDLEN	= 0x0002;
-errors.ESME_RINVCMDID	= 0x0003;
-errors.ESME_RINVBNDSTS	= 0x0004;
-errors.ESME_RALYBND	= 0x0005;
-errors.ESME_RINVPRTFLG	= 0x0006;
-errors.ESME_RINVREGDLVFLG	= 0x0007;
-errors.ESME_RSYSERR	= 0x0008;
-errors.ESME_RINVSRCADR	= 0x000A;
-errors.ESME_RINVDSTADR	= 0x000B;
-errors.ESME_RINVMSGID	= 0x000C;
-errors.ESME_RBINDFAIL	= 0x000D;
-errors.ESME_RINVPASWD	= 0x000E;
-errors.ESME_RINVSYSID	= 0x000F;
-errors.ESME_RCANCELFAIL	= 0x0011;
-errors.ESME_RREPLACEFAIL	= 0x0013;
-errors.ESME_RMSGQFUL	= 0x0014;
-errors.ESME_RINVSERTYP	= 0x0015;
-errors.ESME_RINVNUMDESTS	= 0x0033;
-errors.ESME_RINVDLNAME	= 0x0034;
-errors.ESME_RINVDESTFLAG	= 0x0040;
-errors.ESME_RINVSUBREP	= 0x0042;
-errors.ESME_RINVESMCLASS	= 0x0043;
-errors.ESME_RCNTSUBDL	= 0x0044;
-errors.ESME_RSUBMITFAIL	= 0x0045;
-errors.ESME_RINVSRCTON	= 0x0048;
-errors.ESME_RINVSRCNPI	= 0x0049;
-errors.ESME_RINVDSTTON	= 0x0050;
-errors.ESME_RINVDSTNPI	= 0x0051;
-errors.ESME_RINVSYSTYP	= 0x0053;
-errors.ESME_RINVREPFLAG	= 0x0054;
-errors.ESME_RINVNUMMSGS	= 0x0055;
-errors.ESME_RTHROTTLED	= 0x0058;
-errors.ESME_RINVSCHED	= 0x0061;
-errors.ESME_RINVEXPIRY	= 0x0062;
-errors.ESME_RINVDFTMSGID	= 0x0063;
-errors.ESME_RX_T_APPN	= 0x0064;
-errors.ESME_RX_P_APPN	= 0x0065;
-errors.ESME_RX_R_APPN	= 0x0066;
-errors.ESME_RQUERYFAIL	= 0x0067;
-errors.ESME_RINVTLVSTREAM	= 0x00C0;
-errors.ESME_RTLVNOTALLWD	= 0x00C1;
-errors.ESME_RINVTLVLEN	= 0x00C2;
-errors.ESME_RMISSINGTLV	= 0x00C3;
-errors.ESME_RINVTLVVAL	= 0x00C4;
-errors.ESME_RDELIVERYFAILURE	= 0x00FE;
-errors.ESME_RUNKNOWNERR	= 0x00FF;
-errors.ESME_RSERTYPUNAUTH	= 0x0100;
-errors.ESME_RPROHIBITED	= 0x0101;
-errors.ESME_RSERTYPUNAVAIL	= 0x0102;
-errors.ESME_RSERTYPDENIED	= 0x0103;
-errors.ESME_RINVDCS	= 0x0104;
-errors.ESME_RINVSRCADDRSUBUNIT	= 0x0105;
-errors.ESME_RINVDSTADDRSUBUNIT	= 0x0106;
-errors.ESME_RINVBCASTFREQINT	= 0x0107;
-errors.ESME_RINVBCASTALIAS_NAME	= 0x0108;
-errors.ESME_RINVBCASTAREAFMT	= 0x0109;
-errors.ESME_RINVNUMBCAST_AREAS	= 0x010A;
-errors.ESME_RINVBCASTCNTTYPE	= 0x010B;
-errors.ESME_RINVBCASTMSGCLASS	= 0x010C;
-errors.ESME_RBCASTFAIL	= 0x010D;
-errors.ESME_RBCASTQUERYFAIL	= 0x010E;
-errors.ESME_RBCASTCANCELFAIL	= 0x010F;
-errors.ESME_RINVBCAST_REP	= 0x0110;
-errors.ESME_RINVBCASTSRVGRP	= 0x0111;
-errors.ESME_RINVBCASTCHANIND	= 0x011;
+tlvs.alert_on_msg_delivery = tlvs.alert_on_message_delivery;
+tlvs.failed_broadcast_area_identifier = tlvs.broadcast_area_identifier;
 
-for (const error in errors) {
+cmds = {
+	alert_notification: {
+		id: 0x00000102,
+		params: {
+			source_addr_ton: {type: types.int8},
+			source_addr_npi: {type: types.int8},
+			source_addr: {type: types.cstring},
+			esme_addr_ton: {type: types.int8},
+			esme_addr_npi: {type: types.int8},
+			esme_addr: {type: types.cstring}
+		}
+	},
+	bind_receiver: {
+		id: 0x00000001,
+		params: {
+			system_id: {type: types.cstring},
+			password: {type: types.cstring},
+			system_type: {type: types.cstring},
+			interface_version: {type: types.int8, default: 0x50},
+			addr_ton: {type: types.int8},
+			addr_npi: {type: types.int8},
+			address_range: {type: types.cstring}
+		}
+	},
+	bind_receiver_resp: {
+		id: 0x80000001,
+		params: {
+			system_id: {type: types.cstring}
+		}
+	},
+	bind_transmitter: {
+		id: 0x00000002,
+		params: {
+			system_id: {type: types.cstring},
+			password: {type: types.cstring},
+			system_type: {type: types.cstring},
+			interface_version: {type: types.int8, default: 0x50},
+			addr_ton: {type: types.int8},
+			addr_npi: {type: types.int8},
+			address_range: {type: types.cstring}
+		}
+	},
+	bind_transmitter_resp: {
+		id: 0x80000002,
+		params: {
+			system_id: {type: types.cstring}
+		}
+	},
+	bind_transceiver: {
+		id: 0x00000009,
+		params: {
+			system_id: {type: types.cstring},
+			password: {type: types.cstring},
+			system_type: {type: types.cstring},
+			interface_version: {type: types.int8, default: 0x50},
+			addr_ton: {type: types.int8},
+			addr_npi: {type: types.int8},
+			address_range: {type: types.cstring}
+		}
+	},
+	bind_transceiver_resp: {
+		id: 0x80000009,
+		params: {
+			system_id: {type: types.cstring}
+		}
+	},
+	broadcast_sm: {
+		id: 0x00000111,
+		params: {
+			service_type: {type: types.cstring},
+			source_addr_ton: {type: types.int8},
+			source_addr_npi: {type: types.int8},
+			source_addr: {type: types.cstring},
+			message_id: {type: types.cstring},
+			priority_flag: {type: types.int8},
+			schedule_delivery_time:	{type: types.cstring, filter: filters.time},
+			validity_period: {type: types.cstring, filter: filters.time},
+			replace_if_present_flag: {type: types.int8},
+			data_coding: {type: types.int8},
+			sm_default_msg_id: {type: types.int8}
+		}
+	},
+	broadcast_sm_resp: {
+		id: 0x80000111,
+		params: {
+			message_id: {type: types.cstring}
+		},
+		tlvMap: {
+			broadcast_area_identifier: 'failed_broadcast_area_identifier'
+		}
+	},
+	cancel_broadcast_sm: {
+		id: 0x00000113,
+		params: {
+			service_type: {type: types.cstring},
+			message_id: {type: types.cstring},
+			source_addr_ton: {type: types.int8},
+			source_addr_npi: {type: types.int8},
+			source_addr: {type: types.cstring}
+		}
+	},
+	cancel_broadcast_sm_resp: {
+		id: 0x80000113
+	},
+	cancel_sm: {
+		id: 0x00000008,
+		params: {
+			service_type: {type: types.cstring},
+			message_id: {type: types.cstring},
+			source_addr_ton: {type: types.int8},
+			source_addr_npi: {type: types.int8},
+			source_addr: {type: types.cstring},
+			dest_addr_ton: {type: types.int8},
+			dest_addr_npi: {type: types.int8},
+			destination_addr: {type: types.cstring}
+		}
+	},
+	cancel_sm_resp: {
+		id: 0x80000008
+	},
+	data_sm: {
+		id: 0x00000103,
+		params: {
+			service_type: {type: types.cstring},
+			source_addr_ton: {type: types.int8},
+			source_addr_npi: {type: types.int8},
+			source_addr: {type: types.cstring},
+			dest_addr_ton: {type: types.int8},
+			dest_addr_npi: {type: types.int8},
+			destination_addr: {type: types.cstring},
+			esm_class: {type: types.int8},
+			registered_delivery: {type: types.int8},
+			data_coding: {type: types.int8}
+		}
+	},
+	data_sm_resp: {
+		id: 0x80000103,
+		params: {
+			message_id: {type: types.cstring}
+		}
+	},
+	deliver_sm: {
+		id: 0x00000005,
+		params: {
+			service_type: {type: types.cstring},
+			source_addr_ton: {type: types.int8},
+			source_addr_npi: {type: types.int8},
+			source_addr: {type: types.cstring},
+			dest_addr_ton: {type: types.int8},
+			dest_addr_npi: {type: types.int8},
+			destination_addr: {type: types.cstring},
+			esm_class: {type: types.int8},
+			protocol_id: {type: types.int8},
+			priority_flag: {type: types.int8},
+			schedule_delivery_time: {type: types.cstring, filter: filters.time},
+			validity_period: {type: types.cstring, filter: filters.time},
+			registered_delivery: {type: types.int8},
+			replace_if_present_flag: {type: types.int8},
+			data_coding: {type: types.int8},
+			sm_default_msg_id: {type: types.int8},
+			sm_length: {type: types.int8},
+			short_message: {type: types.buffer, filter: filters.message}
+		}
+	},
+	deliver_sm_resp: {
+		id: 0x80000005,
+		params: {
+			message_id: {type: types.cstring}
+		}
+	},
+	enquire_link: {
+		id: 0x00000015
+	},
+	enquire_link_resp: {
+		id: 0x80000015
+	},
+	generic_nack: {
+		id: 0x80000000
+	},
+	outbind: {
+		id: 0x0000000B,
+		params: {
+			system_id: {type: types.cstring},
+			password: {type: types.cstring}
+		}
+	},
+	query_broadcast_sm: {
+		id: 0x00000112,
+		params: {
+			message_id: {type: types.cstring},
+			source_addr_ton: {type: types.int8},
+			source_addr_npi: {type: types.int8},
+			source_addr: {type: types.cstring}
+		}
+	},
+	query_broadcast_sm_resp: {
+		id: 0x80000112,
+		params: {
+			message_id: {type: types.cstring}
+		}
+	},
+	query_sm: {
+		id: 0x00000003,
+		params: {
+			message_id: {type: types.cstring},
+			source_addr_ton: {type: types.int8},
+			source_addr_npi: {type: types.int8},
+			source_addr: {type: types.cstring}
+		}
+	},
+	query_sm_resp: {
+		id: 0x80000003,
+		params: {
+			message_id: {type: types.cstring},
+			final_date: {type: types.cstring, filter: filters.time},
+			message_state: {type: types.int8},
+			error_code: {type: types.int8}
+		}
+	},
+	replace_sm: {
+		id: 0x00000007,
+		params: {
+			message_id: {type: types.cstring},
+			source_addr_ton: {type: types.int8},
+			source_addr_npi: {type: types.int8},
+			source_addr: {type: types.cstring},
+			schedule_delivery_time: {type: types.cstring, filter: filters.time},
+			validity_period: {type: types.cstring, filter: filters.time},
+			registered_delivery: {type: types.int8},
+			sm_default_msg_id: {type: types.int8},
+			sm_length: {type: types.int8},
+			short_message: {type: types.buffer, filter: filters.message}
+		}
+	},
+	replace_sm_resp: {
+		id: 0x80000007
+	},
+	submit_multi: {
+		id: 0x00000021,
+		params: {
+			service_type: {type: types.cstring},
+			source_addr_ton: {type: types.int8},
+			source_addr_npi: {type: types.int8},
+			source_addr: {type: types.cstring},
+			//number_of_dests: {type: types.int8},
+			dest_address: {type: types.dest_address_array},
+			esm_class: {type: types.int8},
+			protocol_id: {type: types.int8},
+			priority_flag: {type: types.int8},
+			schedule_delivery_time: {type: types.cstring, filter: filters.time},
+			validity_period: {type: types.cstring, filter: filters.time},
+			registered_delivery: {type: types.int8},
+			replace_if_present_flag: {type: types.int8},
+			data_coding: {type: types.int8},
+			sm_default_msg_id: {type: types.int8},
+			//sm_length: {type: types.int8},
+			short_message: {type: types.buffer, filter: filters.message}
+		}
+	},
+	submit_multi_resp: {
+		id: 0x80000021,
+		params: {
+			message_id: {type: types.cstring},
+			//no_unsuccess: {type: types.int8},
+			unsuccess_sme: {type: types.unsuccess_sme_array}
+		}
+	},
+	submit_sm: {
+		id: 0x00000004,
+		params: {
+			service_type: {type: types.cstring},
+			source_addr_ton: {type: types.int8},
+			source_addr_npi: {type: types.int8},
+			source_addr: {type: types.cstring},
+			dest_addr_ton: {type: types.int8},
+			dest_addr_npi: {type: types.int8},
+			destination_addr: {type: types.cstring},
+			esm_class: {type: types.int8},
+			protocol_id: {type: types.int8},
+			priority_flag: {type: types.int8},
+			schedule_delivery_time: {type: types.cstring, filter: filters.time},
+			validity_period: {type: types.cstring, filter: filters.time},
+			registered_delivery: {type: types.int8},
+			replace_if_present_flag: {type: types.int8},
+			data_coding: {type: types.int8},
+			sm_default_msg_id: {type: types.int8},
+			sm_length: {type: types.int8},
+			short_message: {type: types.buffer, filter: filters.message}
+		}
+	},
+	submit_sm_resp: {
+		id: 0x80000004,
+		params: {
+			message_id: {type: types.cstring}
+		}
+	},
+	unbind: {
+		id: 0x00000006
+	},
+	unbind_resp: {
+		id: 0x80000006
+	}
+};
+
+cmdsById = {};
+
+for (command in cmds) {
+	cmdsById[cmds[command].id] = cmds[command];
+	cmds[command].command = command;
+}
+
+errors = {
+	ESME_ROK:                 0x0000,
+	ESME_RINVMSGLEN:          0x0001,
+	ESME_RINVCMDLEN:          0x0002,
+	ESME_RINVCMDID:           0x0003,
+	ESME_RINVBNDSTS:          0x0004,
+	ESME_RALYBND:             0x0005,
+	ESME_RINVPRTFLG:          0x0006,
+	ESME_RINVREGDLVFLG:       0x0007,
+	ESME_RSYSERR:             0x0008,
+	ESME_RINVSRCADR:          0x000A,
+	ESME_RINVDSTADR:          0x000B,
+	ESME_RINVMSGID:           0x000C,
+	ESME_RBINDFAIL:           0x000D,
+	ESME_RINVPASWD:           0x000E,
+	ESME_RINVSYSID:           0x000F,
+	ESME_RCANCELFAIL:         0x0011,
+	ESME_RREPLACEFAIL:        0x0013,
+	ESME_RMSGQFUL:            0x0014,
+	ESME_RINVSERTYP:          0x0015,
+	ESME_RINVNUMDESTS:        0x0033,
+	ESME_RINVDLNAME:          0x0034,
+	ESME_RINVDESTFLAG:        0x0040,
+	ESME_RINVSUBREP:          0x0042,
+	ESME_RINVESMCLASS:        0x0043,
+	ESME_RCNTSUBDL:           0x0044,
+	ESME_RSUBMITFAIL:         0x0045,
+	ESME_RINVSRCTON:          0x0048,
+	ESME_RINVSRCNPI:          0x0049,
+	ESME_RINVDSTTON:          0x0050,
+	ESME_RINVDSTNPI:          0x0051,
+	ESME_RINVSYSTYP:          0x0053,
+	ESME_RINVREPFLAG:         0x0054,
+	ESME_RINVNUMMSGS:         0x0055,
+	ESME_RTHROTTLED:          0x0058,
+	ESME_RINVSCHED:           0x0061,
+	ESME_RINVEXPIRY:          0x0062,
+	ESME_RINVDFTMSGID:        0x0063,
+	ESME_RX_T_APPN:           0x0064,
+	ESME_RX_P_APPN:           0x0065,
+	ESME_RX_R_APPN:           0x0066,
+	ESME_RQUERYFAIL:          0x0067,
+	ESME_RINVTLVSTREAM:       0x00C0,
+	ESME_RTLVNOTALLWD:        0x00C1,
+	ESME_RINVTLVLEN:          0x00C2,
+	ESME_RMISSINGTLV:         0x00C3,
+	ESME_RINVTLVVAL:          0x00C4,
+	ESME_RDELIVERYFAILURE:    0x00FE,
+	ESME_RUNKNOWNERR:         0x00FF,
+	ESME_RSERTYPUNAUTH:       0x0100,
+	ESME_RPROHIBITED:         0x0101,
+	ESME_RSERTYPUNAVAIL:      0x0102,
+	ESME_RSERTYPDENIED:       0x0103,
+	ESME_RINVDCS:             0x0104,
+	ESME_RINVSRCADDRSUBUNIT:  0x0105,
+	ESME_RINVDSTADDRSUBUNIT:  0x0106,
+	ESME_RINVBCASTFREQINT:    0x0107,
+	ESME_RINVBCASTALIAS_NAME: 0x0108,
+	ESME_RINVBCASTAREAFMT:    0x0109,
+	ESME_RINVNUMBCAST_AREAS:  0x010A,
+	ESME_RINVBCASTCNTTYPE:    0x010B,
+	ESME_RINVBCASTMSGCLASS:   0x010C,
+	ESME_RBCASTFAIL:          0x010D,
+	ESME_RBCASTQUERYFAIL:     0x010E,
+	ESME_RBCASTCANCELFAIL:    0x010F,
+	ESME_RINVBCAST_REP:       0x0110,
+	ESME_RINVBCASTSRVGRP:     0x0111,
+	ESME_RINVBCASTCHANIND:    0x0112
+};
+
+errorsById = {};
+
+for (error in errors) {
 	errorsById[errors[error]] = error;
 }
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -1,68 +1,68 @@
 'use strict';
 
-const	topLogPrefix	= 'larvitsmpp: lib/session.js: ',
-	LUtils	= require('larvitutils'),
-	lUtils	= new LUtils(),
-	events	= require('events'),
-	moment	= require('moment'),
-	utils	= require('./utils'),
-	async	= require('async'),
-	defs	= require('./defs'),
-	uuid	= require('uuid/v1');
+var log    = require('winston'),
+    events = require('events'),
+    moment = require('moment'),
+    utils  = require('./utils'),
+    defs   = require('./defs'),
+    async  = require('async');
 
-/**
+/*
  * Send a response to an sms
  * This must be called from an sms object context
  *
- * @param {string} status - see list at defs.errors - defaults to 'ESME_ROK' - no error (OPTIONAL)
- * @param {function} cb - cb(err, [retPdu, ...])
+ * @param str status - see list at defs.errors - defaults to 'ESME_ROK' - no error (OPTIONAL)
+ * @param func callback(err, [retPdu, ...])
  */
-function smsResp(status, cb) {
-	const	logPrefix	= topLogPrefix + 'smsResp() - ',
-		tasks	= [],
-		sms	= this;
-
-	let	params;
+function smsResp(status, callback) {
+	var sms   = this,
+	    tasks = [],
+	    params,
+	    err,
+	    i;
 
 	if (typeof status === 'function') {
-		cb	= status;
-		status	= true;
+		callback = status;
+		status   = true;
 	}
 
-	if (typeof cb !== 'function') {
-		cb	= function () {};
+	if (typeof callback !== 'function') {
+		callback = function() {};
 	}
 
 	if (sms.smsId === undefined) {
-		sms.smsId	= uuid();
+		sms.smsId = '';
 	}
 
 	// Accept a generic positive status
 	if (status === 'true' || status === true || status === 0) {
-		status	= 'ESME_ROK';
+		status = 'ESME_ROK';
 	}
 
 	// Accept a generic negative status
 	if (status === 'false' || status === false || status === 1) {
-		status	= 'ESME_RUNKNOWNERR'; // Set to unknown error in this case
+		status = 'ESME_RUNKNOWNERR'; // Set to unknown error in this case
 	}
 
 	if (sms.pduObjs === undefined) {
-		const	err	= new Error('No pdu objects found to base return PDU upon');
-		sms.log.warn(logPrefix + err.message);
-		return cb(err);
+		err = new Error('No pdu objects found to base return PDU upon');
+		log.warn('larvitsmpp: lib/session.js: smsResp() - ' + err.message);
+		callback(err);
+		return;
 	}
 
 	// Build async tasks to run the responses in parallel
-	for (let i = 0; sms.pduObjs[i] !== undefined; i ++) {
+	i = 0;
+	while (sms.pduObjs[i] !== undefined) {
 		if (sms.smsId) {
 			if (sms.pduObjs[i].pduObj.params.esm_class === 0x40) {
-				params	= {'message_id': sms.smsId + '-' + (i + 1)};
+				params = {'message_id': sms.smsId + '-' + (i + 1)};
 			} else {
-				params	= {'message_id': sms.smsId};
+				params = {'message_id': sms.smsId};
 			}
 		} else {
-			params	= {};
+			//params = {};
+			 params = {'message_id': sms.smsId || ''};
 		}
 
 		tasks[i] = sms.session.sendReturn.bind(
@@ -72,17 +72,19 @@ function smsResp(status, cb) {
 			params,
 			false
 		);
+
+		i ++;
 	}
 
-	async.parallel(tasks, cb);
+	async.parallel(tasks, callback);
 }
 
 function incOurSeqNr() {
-	this.ourSeqNr	= this.ourSeqNr + 1;
+	this.ourSeqNr = this.ourSeqNr + 1;
 
 	// If we pass the maximum, start over at 1
 	if (this.ourSeqNr > 2147483646) {
-		this.ourSeqNr	= 1;
+		this.ourSeqNr = 1;
 	}
 }
 
@@ -91,32 +93,29 @@ function incOurSeqNr() {
  * Always use this function to close the socket so we get it on log
  */
 function closeSocket() {
-	const	logPrefix	= topLogPrefix + 'closeSocket() - ',
-		that	= this;
-
-	that.log.verbose(logPrefix + 'Closing socket for ' + this.sock.remoteAddress + ':' + this.sock.remotePort);
-	if (that.enqLinkTimer) {
-		that.log.debug(logPrefix + 'enqLinkTimer found, clearing.');
-		clearTimeout(that.enqLinkTimer);
+	log.verbose('larvitsmpp: lib/session.js: closeSocket() - Closing socket for ' + this.sock.remoteAddress + ':' + this.sock.remotePort);
+	if (this.enqLinkTimer) {
+		log.debug('larvitsmpp: lib/session.js: closeSocket() - enqLinkTimer found, clearing.');
+		clearTimeout(this.enqLinkTimer);
 	}
-	that.sock.destroy();
+	this.sock.destroy();
 }
 
 /**
  * Write PDU to socket
  *
- * @param {buffer|object} pdu - can also take PDU object
- * @param {boolean} closeAfterSend - if true will close the socket after sending
+ * @param buf or obj pdu - can also take PDU object
+ * @param bol closeAfterSend - if true will close the socket after sending
  */
 function sockWrite(pdu, closeAfterSend) {
-	const	logPrefix	= topLogPrefix + 'sockWrite() - ',
-		that	= this;
+	var that = this;
 
 	if ( ! Buffer.isBuffer(pdu)) {
-		utils.objToPdu(pdu, function (err, buffer) {
+		utils.objToPdu(pdu, function(err, buffer) {
 			if (err) {
-				that.log.warn(logPrefix + 'Could not convert PDU to buffer');
-				return that.closeSocket();
+				log.warn('larvitsmpp: lib/session.js: sockWrite() - Could not convert PDU to buffer');
+				that.closeSocket();
+				return;
 			}
 
 			that.sockWrite(buffer);
@@ -125,183 +124,186 @@ function sockWrite(pdu, closeAfterSend) {
 	}
 
 	try {
-		that.log.verbose(logPrefix + 'sending PDU. SeqNr: ' + pdu.readUInt32BE(12) + ' cmd: ' + defs.cmdsById[pdu.readUInt32BE(4)].command + ' cmdStatus: ' + defs.errorsById[parseInt(pdu.readUInt32BE(8))] + ' hex: ' + pdu.toString('hex'));
-	} catch (err) {
-		that.log.error(logPrefix + 'PDU buffer is invalid. Buffer hex: "' + pdu.toString('hex') + '"');
+		log.verbose('larvitsmpp: lib/session.js: sockWrite() - sending PDU. SeqNr: ' + pdu.readUInt32BE(12) + ' cmd: ' + defs.cmdsById[pdu.readUInt32BE(4)].command + ' cmdStatus: ' + defs.errorsById[parseInt(pdu.readUInt32BE(8))] + ' hex: ' + pdu.toString('hex'));
+	} catch (e) {
+		log.error('larvitsmpp: lib/session.js: sockWrite() - PDU buffer is invalid. Buffer hex: "' + pdu.toString('hex') + '"');
 		return;
 	}
 
-	that.sock.write(pdu);
+	this.sock.write(pdu);
 
 	if (closeAfterSend) {
-		that.closeSocket();
+		this.closeSocket();
 	}
 }
 
 /**
  * Send a PDU to the remote
  *
- * @param {buffer|object} pdu
- * @param {boolean} closeAfterSend - Will close after return is fetched. Defaults to false (OPTIONAL)
- * @param {function} cb - cb(err, retPdu) (OPTIONAL)
+ * @param buf or obj pdu
+ * @param bol closeAfterSend - Will close after return is fetched. Defaults to false (OPTIONAL)
+ * @param func callback(err, retPdu) (OPTIONAL)
  */
-function send(pdu, closeAfterSend, cb) {
-	const	logPrefix	= topLogPrefix + 'send() - ',
-		pduObj	= pdu,
-		that	= this;
+function send(pdu, closeAfterSend, callback) {
+	var pduObj = pdu,
+	    err    = null,
+	    that   = this;
 
 	// Make sure the pdu is an object
 	if (Buffer.isBuffer(pdu)) {
-		utils.pduToObj(pdu, function (err, pduObj) {
-			if (err) return cb(err);
+		utils.pduToObj(pdu, function(err, pduObj) {
+			if (err) {
+				callback(err);
+				return;
+			}
 
-			that.send(pduObj, closeAfterSend, cb);
+			that.send(pduObj, closeAfterSend, callback);
 		});
 		return;
 	}
 
 	// Make sure the sequence number is set and is correct
-	pduObj.seqNr	= this.ourSeqNr;
+	pduObj.seqNr = this.ourSeqNr;
 
-	that.log.debug(logPrefix + 'Sending PDU to remote. pduObj: ' + JSON.stringify(pduObj));
+	log.debug('larvitsmpp: lib/session.js: send() - Sending PDU to remote. pduObj: ' + JSON.stringify(pduObj));
 
-	// If closeAndSend is omitted, put cb in its place
+	// If closeAndSend is omitted, put callback in its place
 	if (typeof closeAfterSend === 'function') {
-		cb	= closeAfterSend;
-		closeAfterSend	= undefined;
+		callback       = closeAfterSend;
+		closeAfterSend = undefined;
 	}
 
 	// Make sure the callack is a function
-	if (typeof cb !== 'function') {
-		cb	= function () {};
+	if (typeof callback !== 'function') {
+		callback = function(){};
 	}
 
 	// Response PDUs are not allowed with the send() command, they should use the sendReturn()
 	if (pduObj.cmdName.substring(pduObj.cmdName - 5) === '_resp') {
-		const	err = new Error('Given pduObj is a response, use sendReturn() instead. cmdName: ' + pduObj.cmdName);
-		that.log.verbose(logPrefix + err.message);
-		return cb(err);
+		err = new Error('Given pduObj is a response, use sendReturn() instead. cmdName: ' + pduObj.cmdName);
+		callback(err);
+		return;
 	}
 
-	// When the return is fetched, call the cb
-	that.on('incomingPduObj' + pduObj.seqNr, function (incPduObj) {
-		that.log.debug(logPrefix + 'this.on(incomingPduObj) - cmdName: ' + incPduObj.cmdName + ' seqNr: ' + incPduObj.seqNr + ' cmdStatus: ' + incPduObj.cmdStatus);
+	// When the return is fetched, call the callback
+	this.on('incomingPduObj' + pduObj.seqNr, function(incPduObj) {
+
+		log.debug('larvitsmpp: lib/session.js: send() - this.on(incomingPduObj) - cmdName: ' + incPduObj.cmdName + ' seqNr: ' + incPduObj.seqNr + ' cmdStatus: ' + incPduObj.cmdStatus);
 
 		// Make sure this is the actual response to the sent PDU
 		if (incPduObj.isResp() && incPduObj.seqNr === pduObj.seqNr) {
-			cb(null, incPduObj);
+			callback(null, incPduObj);
 
 			if (closeAfterSend) {
 				that.closeSocket();
 			}
 		} else {
-			const	err = new Error('Event triggered but incoming PDU is not a response or seqNr does not match. isResp: ' + incPduObj.isResp().toString() + ' incSeqNr: ' + incPduObj.seqNr + ' expected seqNr: ' + pduObj.seqNr);
-			that.log.warn(logPrefix + 'this.on(incomingPduObj) - ' + err.message);
-			cb(err);
+			err = new Error('Event triggered but incoming PDU is not a response or seqNr does not match. isResp: ' + incPduObj.isResp().toString() + ' incSeqNr: ' + incPduObj.seqNr + ' expected seqNr: ' + pduObj.seqNr);
+			log.warn('larvitsmpp: lib/session.js: send() - this.on(incomingPduObj) - ' + err.message);
+			callback(err);
 		}
 	});
 
 	// Increase our internal sequence number
-	that.incOurSeqNr();
+	this.incOurSeqNr();
 
 	// Write the PDU to socket
-	that.sockWrite(pduObj);
+	this.sockWrite(pduObj);
 }
 
 /**
  * Send a return to given PDU
  *
- * @param {buffer|object} pdu
- * @param {string} status - see list at defs.errors - defaults to 'ESME_ROK' - no error (OPTIONAL)
- * @param {object} [params]
- * @param {boolean} closeAfterSend - if true will close the socket after sending (OPTIONAL)
- * @param {function} [cb(err, retPdu)]
+ * @param obj or buf pdu
+ * @param str status - see list at defs.errors - defaults to 'ESME_ROK' - no error (OPTIONAL)
+ * @param obj params (OPTIONAL)
+ * @param bol closeAfterSend - if true will close the socket after sending (OPTIONAL)
+ * @param func callback(err, retPdu) (OPTIONAL)
  */
-function sendReturn(pdu, status, params, closeAfterSend, cb) {
-	const	logPrefix	= topLogPrefix + 'sendReturn() - ',
-		that	= this;
+function sendReturn(pdu, status, params, closeAfterSend, callback) {
+	var that = this;
 
-	that.log.silly(logPrefix + 'ran');
+	log.silly('larvitsmpp: lib/session.js: sendReturn() - ran');
 
 	if (typeof params === 'function') {
-		cb	= params;
-		params	= undefined;
-		closeAfterSend	= undefined;
+		callback       = params;
+		params         = undefined;
+		closeAfterSend = undefined;
 	}
 
 	if (typeof closeAfterSend === 'function') {
-		cb	= closeAfterSend;
-		closeAfterSend	= undefined;
+		callback       = closeAfterSend;
+		closeAfterSend = undefined;
 	}
 
-	if (typeof cb !== 'function') {
-		cb	= function () {};
+	if (typeof callback !== 'function') {
+		callback = function() {};
 	}
 
-	utils.pduReturn(pdu, status, params, function (err, retPdu) {
+
+
+	utils.pduReturn(pdu, status, params, function(err, retPdu) {
 		if (err) {
-			that.log.error(logPrefix + 'Could not create return PDU: ' + err.message);
+			log.error('larvitsmpp: lib/session.js: sendReturn() - Could not create return PDU: ' + err.message);
 			that.closeSocket();
 
-			return cb(err);
+			callback(err);
+			return;
 		}
 
-		that.log.silly(logPrefix + 'Sending return PDU: ' + retPdu.toString('hex'));
+		log.silly('larvitsmpp: lib/session.js: sendReturn() - Sending return PDU: ' + retPdu.toString('hex'));
 		that.sockWrite(retPdu, closeAfterSend);
-		cb(null, retPdu);
+		callback(null, retPdu);
 	});
 }
 
 /**
  * Send an SMS
  *
- * @param {object}	smsOptions	{
- *			from	- alphanum or international format
- *			to	- international format
- *			message	- string
- *			dlr	- boolean defaults to false
- *			flash	- boolean defaults to false
- *		}
- * @param {function}	cb(err, smsIds, retPduObjs)
+ * @param obj smsOptions
+ *                       from - alphanum or international format
+ *                       to - international format
+ *                       message - string
+ *                       dlr - boolean defaults to false
+ *                       flash - boolean defaults to false
+ * @param func callback(err, smsIds, retPduObjs)
  */
-function sendSms(smsOptions, cb) {
-	const	logPrefix	= topLogPrefix	+ 'sendSms() - ',
-		pduObj	= {},
-		that	= this;
+function sendSms(smsOptions, callback) {
+	var pduObj = {};
 
-	pduObj.cmdName	= 'submit_sm';
+	pduObj.cmdName = 'submit_sm';
 	pduObj.params  = {
-		'source_addr_ton':	1, // Default to international format
-		'source_addr':	smsOptions.from,
-		'destination_addr':	smsOptions.to,
-		'short_message':	smsOptions.message
+		'source_addr_ton':  1, // Default to international format
+		'source_addr':      smsOptions.from,
+		'destination_addr': smsOptions.to,
+		'short_message':    smsOptions.message
 	};
 
 	// Flash messages overrides default data_coding
 	if (smsOptions.flash) {
-		that.log.debug(logPrefix + 'Flash SMS detected, set data_coding to 0x10!');
-		pduObj.params.data_coding	= 0x10;
+		log.debug('larvitsmpp: lib/session.js: sendSms() - Flash SMS detected, set data_coding to 0x10!');
+		pduObj.params.data_coding = 0x10;
 	}
 
 	// Request DLRs!
 	if (smsOptions.dlr) {
-		pduObj.params.registered_delivery	= 0x01;
+		pduObj.params.registered_delivery = 0x01;
 	}
 
 	// Check if we must split this message into multiple
 	if (utils.bitCount(smsOptions.message) > 1120) {
-		that.log.debug(logPrefix + 'Message larger than 1120 bits, send it as long message!');
+		log.debug('larvitsmpp: lib/session.js: sendSms() - Message larger than 1120 bits, send it as long message!');
 
-		that.sendLongSms(smsOptions, cb);
+		this.sendLongSms(smsOptions, callback);
 
 		return;
 	}
 
-	that.log.debug(logPrefix + 'pduObj: ' + JSON.stringify(pduObj));
+	log.debug('larvitsmpp: lib/session.js: sendSms() - pduObj: ' + JSON.stringify(pduObj));
 
-	that.send(pduObj, function (err, retPduObj) {
-		if (typeof cb === 'function') {
-			cb(err, [retPduObj.params.message_id], [retPduObj]);
+	this.send(pduObj, function(err, retPduObj) {
+		if (typeof callback === 'function') {
+			callback(err, [retPduObj.params.message_id], [retPduObj]);
 		}
 	});
 }
@@ -309,52 +311,50 @@ function sendSms(smsOptions, cb) {
 /**
  * Send a longer SMS than 1120 bits
  *
- * @param {object}	smsOptions	{
- *			from	- alphanum or international format
- *			to	- international format
- *			message	- string
- *			dlr	- boolean defaults to false
- *		}
- * @param {function}	cb - cb(err, smsId, retPduObj)
+ * @param obj smsOptions
+ *                       from - alphanum or international format
+ *                       to - international format
+ *                       message - string
+ *                       dlr - boolean defaults to false
+ * @param func callback(err, smsId, retPduObj)
  */
-function sendLongSms(smsOptions, cb) {
-	const	retPduObjs	= [],
-		logPrefix	= topLogPrefix + 'sendLongSms() - ',
-		encoding	= defs.encodings.detect(smsOptions.message), // Set encoding once for all message parts
-		smsIds	= [],
-		that	= this,
-		msgs	= utils.splitMsg(smsOptions.message);
+function sendLongSms(smsOptions, callback) {
+	var that       = this,
+	    smsIds     = [],
+	    retPduObjs = [],
+	    msgs       = utils.splitMsg(smsOptions.message),
+	    encoding   = defs.encodings.detect(smsOptions.message); // Set encoding once for all message parts
 
 	function sendPart(i) {
-		const pduObj = {
-			'cmdName':	'submit_sm',
+		var pduObj = {
+			'cmdName': 'submit_sm',
 			'params': {
-				'source_addr_ton':	1, // Default to international format
-				'esm_class':	0x40, // This indicates that there is a UDH in the short_message
-				'source_addr':	smsOptions.from,
-				'destination_addr':	smsOptions.to,
-				'data_coding':	defs.consts.ENCODING[encoding],
-				'short_message':	msgs[i],
-				'sm_length':	msgs[i].length
+				'source_addr_ton': 1, // Default to international format
+				'esm_class': 0x40, // This indicates that there is a UDH in the short_message
+				'source_addr': smsOptions.from,
+				'destination_addr': smsOptions.to,
+				'data_coding': defs.consts.ENCODING[encoding],
+				'short_message': msgs[i],
+				'sm_length': msgs[i].length
 			}
 		};
 
 		// Request DLRs!
 		if (smsOptions.dlr) {
-			pduObj.params.registered_delivery	= 0x01;
+			pduObj.params.registered_delivery = 0x01;
 		}
 
-		that.log.debug(logPrefix + 'pduObj: ' + JSON.stringify(pduObj));
+		log.debug('larvitsmpp: lib/session.js: sendLongSms() - pduObj: ' + JSON.stringify(pduObj));
 
-		that.send(pduObj, function (err, retPduObj) {
+		that.send(pduObj, function(err, retPduObj) {
 			smsIds.push(retPduObj.params.message_id);
 			retPduObjs.push(retPduObj);
 
-			that.log.silly(logPrefix + 'Got cb from that.send()');
+			log.silly('larvitsmpp: lib/session.js: sendLongSms() - Got callback from that.send()');
 
-			if (typeof cb === 'function' && smsIds.length === msgs.length) {
-				that.log.silly(logPrefix + 'All cbs returned, run the parent cb.');
-				cb(err, smsIds, retPduObjs);
+			if (typeof callback === 'function' && smsIds.length === msgs.length) {
+				log.silly('larvitsmpp: lib/session.js: sendLongSms() - All callbacks returned, run the parent callback.');
+				callback(err, smsIds, retPduObjs);
 			}
 		});
 
@@ -368,39 +368,44 @@ function sendLongSms(smsOptions, cb) {
 
 // Store long smses in the temporary storage
 function longSms(pduObj) {
-	// Fix:	UDH values are stored in HEX and decoding them make it garbage. First OCTET contains
-	//	the size of UDH data header. If UDH data header size is 0x05 then field 4 i.e. CSMS
-	//	reference number is of one octet otherwise it consists of 2 octets. Other fields can
-	//	be found from below reference.
-	//	reference: https://en.wikipedia.org/wiki/Concatenated_SMS
+	// Fix: UDH values are stored in HEX and decoding them make it garbage. First OCTET contains
+	//      the size of UDH data header. If UDH data header size is 0x05 then field 4 i.e. CSMS
+	//      reference number is of one octet otherwise it consists of 2 octets. Other fields can
+	//      be found from below reference.
+	//      reference: https://en.wikipedia.org/wiki/Concatenated_SMS
+	var udhHeaderSize = pduObj.params.short_message[0], // First octet is the size of UDH Header
+	    headerSize    = pduObj.params.short_message[2], // Header size other than first 2 octets
+	    csmsReference = pduObj.params.short_message.slice(3, 3 + headerSize - 2), // CSMS Reference starts from
+	                                                                              // 4th octet and length is
+	                                                                              // header size -2 octets
+	    partsCount    = pduObj.params.short_message[2 + csmsReference.length + 1],
+	    partNr        = pduObj.params.short_message[2 + csmsReference.length + 2],
+	    longSmsId     = pduObj.params.source_addr + '_' + pduObj.params.destination_addr + '_' + csmsReference;
 
-	const	udhHeaderSize	= pduObj.params.short_message[0],	// First octet is the size of UDH Header
-		headerSize	= pduObj.params.short_message[2],	// Header size other than first 2 octets
-		csmsReference	= pduObj.params.short_message.slice(3, 3 + headerSize - 2),	// CSMS Reference starts from 4th octet and length is header size -2 octets
-		partsCount	= pduObj.params.short_message[2 + csmsReference.length + 1],
-		longSmsId	= pduObj.params.source_addr + '_' + pduObj.params.destination_addr + '_' + csmsReference,
-		partNr	= pduObj.params.short_message[2 + csmsReference.length + 2],
-		that	= this;
+	        var msgId = require('uuid').v4();
+	        this.sendReturn(pduObj, 'ESME_ROK', {'message_id': msgId}, false);
 
-	if (that.longSmses[longSmsId] === undefined) {
-		that.longSmses[longSmsId] = {
-			'created':	new Date(),
-			'partsCount':	partsCount,
-			'udhSize':	udhHeaderSize,	// Saving udh size to remove garbage from message
+	if (this.longSmses[longSmsId] === undefined) {
+		this.longSmses[longSmsId] = {
+			'created': new Date(),
+			'partsCount': partsCount,
+			'udhSize': udhHeaderSize, // Saving udh size to remove garbage from message
+			'msgId':      msgId,
 			'pduObjs': [{
-				'partNr':	partNr,	// We save this here to easier sort the array later on
-				'pduObj':	pduObj
+				'partNr': partNr, // We save this here to easier sort the array later on
+				'pduObj': pduObj,
+				'msgId':  msgId
 			}]
 		};
 	} else {
-		that.longSmses[longSmsId].pduObjs.push({
-			'partNr':	partNr, // We save this here to easier sort the array later on
-			'pduObj':	pduObj
+		this.longSmses[longSmsId].pduObjs.push({
+			'partNr': partNr, // We save this here to easier sort the array later on
+			'pduObj': pduObj
 		});
 	}
 
 	// Check the long messages tmp storage to see if we should handle them
-	that.checkLongSmses();
+	this.checkLongSmses();
 }
 
 // Sort function to sort group parts
@@ -419,11 +424,15 @@ function sortLongSmsPdus(a, b) {
 // Walk through the long sms storage to investigate if we can send complete messages along
 // or should remove old ones
 function checkLongSmses() {
-	const	logPrefix	= topLogPrefix	+ 'checkLongSmses() - ',
-		smsObj	= {},
-		that	= this;
+	var that = this,
+	    smsGroupId,
+	    smsGroup,
+	    udhSize, // UDH Size from longSms() function
+	    smsObj,
+	    i,
+	    curPduObj;
 
-	that.log.silly(logPrefix + 'Running');
+	log.silly('larvitsmpp: lib/session.js: checkLongSmses() - Running');
 
 	// Call when complete SMS is received
 	function smsReceived() {
@@ -433,42 +442,45 @@ function checkLongSmses() {
 		delete that.longSmses[smsObj.smsGroupId];
 	}
 
-	for (const smsGroupId in this.longSmses) {
-		const	smsGroup	= this.longSmses[smsGroupId],
-			udhSize	= smsGroup.udhSize;
-
+	for (smsGroupId in this.longSmses) {
+		smsGroup = this.longSmses[smsGroupId];
+		udhSize = smsGroup.udhSize;
 		// All parts are accounted for! Emit sms event and clear from tmp storage
 		if (smsGroup.partsCount === smsGroup.pduObjs.length) {
-			that.log.debug(logPrefix + 'All parts accounted for in smsGroupId "' + smsGroupId + '", emitting sms event.');
+			log.debug('larvitsmpp: lib/session.js: checkLongSmses() - All parts accounted for in smsGroupId "' + smsGroupId + '", emitting sms event.');
 
-			// These are needed for references here and there in functions
-			smsObj.session	= that;
-			smsObj.smsGroupId	= smsGroupId;
-			smsObj.pduObjs	= smsGroup.pduObjs;
-			smsObj.from	= smsGroup.pduObjs[0].pduObj.params.source_addr;
-			smsObj.to	= smsGroup.pduObjs[0].pduObj.params.destination_addr;
-			smsObj.submitTime	= new Date();
-			smsObj.message	= '';
-			smsObj.dlr	= Boolean(smsGroup.pduObjs[0].pduObj.params.registered_delivery);
-			smsObj.sendResp	= smsResp;
-			smsObj.sendDlr	= utils.smsDlr;
-			smsObj.log	= that.log;
+			smsObj = {
+				// These are needed for references here and there in functions
+				'session':    that,
+				'smsGroupId': smsGroupId,
+				'pduObjs':    smsGroup.pduObjs,
+				'from':       smsGroup.pduObjs[0].pduObj.params.source_addr,
+				'to':         smsGroup.pduObjs[0].pduObj.params.destination_addr,
+				'submitTime': new Date(),
+				'message':    '',
+				 'smsId':      smsGroup.msgId,
+				'dlr':        Boolean(smsGroup.pduObjs[0].pduObj.params.registered_delivery),
+				'sendResp':   smsResp,
+				'sendDlr':    utils.smsDlr
+			};
 
 			// Concatenate all the parts messages to one and set references to the session
 
 			// First we need to sort the parts, since they can come in random order
 			smsObj.pduObjs.sort(sortLongSmsPdus);
 
-			for (let i = 0; smsObj.pduObjs[i] !== undefined; i ++) {
-				const	curPduObj	= smsObj.pduObjs[i].pduObj;
+			i = 0;
+			while (smsObj.pduObjs[i] !== undefined) {
+				curPduObj         = smsObj.pduObjs[i].pduObj;
+				curPduObj.session = this;
 
-				curPduObj.session	= this;
+				smsObj.message += utils.decodeMsg(curPduObj.params.short_message, curPduObj.params.data_coding, udhSize + 1);
 
-				smsObj.message	+= utils.decodeMsg(curPduObj.params.short_message, curPduObj.params.data_coding, udhSize + 1);
+				i ++;
 			}
 			smsReceived();
 		} else if (moment(new Date()).diff(smsGroup.created, 'hours') > 24) {
-			that.log.info(logPrefix + 'smsGroupId "' + smsGroupId + '" is removed from this.longSmses due to being older than 24 hours.');
+			log.info('larvitsmpp: lib/session.js: checkLongSmses() - smsGroupId "' + smsGroupId + '" is removed from this.longSmses due to being older than 24 hours.');
 
 			delete this.longSmses[smsGroupId];
 		}
@@ -478,57 +490,53 @@ function checkLongSmses() {
 /**
  * Generic session function
  *
- * @param {object} options - {sock, log}
- * @return {object} (returnObj)
+ * @param obj sock - socket object
+ * @return obj (returnObj)
  */
-function session(options) {
-	const	logPrefix	= topLogPrefix + 'session() - socket address: ' + options.sock.remoteAddress + ':' + options.sock.remotePort + ' - ',
-		returnObj	= new events.EventEmitter();
+function session(sock) {
+	var returnObj = new events.EventEmitter();
 
-	if (! options.log) {
-		options.log	= new lUtils.Log();
-	}
-	utils.log	= options.log;
+	log.silly('larvitsmpp: lib/session.js: session() - New session started from ' + sock.remoteAddress + ':' + sock.remotePort);
 
-	returnObj.log	= options.log;
+	returnObj.loggedIn = false;
 
-	returnObj.log.silly(logPrefix + 'New session started');
+	// Sequence number used for commands initiated from us
+	returnObj.ourSeqNr = 1;
 
-	returnObj.loggedIn	= false;
-	returnObj.ourSeqNr	= 1;	// Sequence number used for commands initiated from us
-	returnObj.sock	= options.sock;	// Make the socket transparent via the returned emitter
-	returnObj.incOurSeqNr	= incOurSeqNr;
-	returnObj.closeSocket	= closeSocket;
-	returnObj.sockWrite	= sockWrite;
-	returnObj.send	= send;
-	returnObj.sendReturn	= sendReturn;
-	returnObj.sendSms	= sendSms;
-	returnObj.utils	= utils;
+	// Make the socket transparent via the returned emitter
+	returnObj.sock = sock;
+
+	returnObj.incOurSeqNr = incOurSeqNr;
+	returnObj.closeSocket = closeSocket;
+	returnObj.sockWrite   = sockWrite;
+	returnObj.send        = send;
+	returnObj.sendReturn  = sendReturn;
+	returnObj.sendSms     = sendSms;
+	returnObj.utils       = utils;
 
 	// Temporary storage for long sms parts
-	// These should be cleared if they linger to long to avoid memory leaks
-	returnObj.longSmses	= {};
+	// These should be cleared if they lingre to long to avoid memory leaks
+	returnObj.longSmses = {};
 
-	// Temporary storage for DLRs to long SMSes
+	// Temporary storage for DLRs to long smses
 	// We keep them like this to be able to simulate a single DLR when all parts have gotten DLRs
-	returnObj.longSmsDlrs	= {};
+	returnObj.longSmsDlrs = {};
 
-	returnObj.sendLongSms	= sendLongSms;
-	returnObj.longSms	= longSms;
-	returnObj.checkLongSmses	= checkLongSmses;
+	returnObj.sendLongSms    = sendLongSms;
+	returnObj.longSms        = longSms;
+	returnObj.checkLongSmses = checkLongSmses;
 
 	// Handle incomming commands.
 	// This is intended to be extended
-	returnObj.handleCmd	= {};
+	returnObj.handleCmd = {};
 
 	// Handle incoming deliver_sm
-	returnObj.handleCmd.deliver_sm = function deliver_sm(pduObj) {
-		const	thisLogPrefix	= logPrefix + 'deliver_sm() - ',
-			dlrObj	= {};
+	returnObj.handleCmd.deliver_sm = function(pduObj) {
+		var dlrObj;
 
 		// TLV message_state must exists
 		if (pduObj.tlvs.message_state === undefined) {
-			returnObj.log.info(thisLogPrefix + 'TLV message_state is missing. SeqNr: ' + pduObj.seqNr);
+			log.info('larvitsmpp: lib/session.js: session() - returnObj.handleCmd.deliver_sm() - TLV message_state is missing. SeqNr: ' + pduObj.seqNr);
 			returnObj.sendReturn(pduObj, 'ESME_RINVTLVSTREAM');
 
 			return;
@@ -536,7 +544,7 @@ function session(options) {
 
 		// TLV message_state needs to be valid
 		if (defs.constsById.MESSAGE_STATE[pduObj.tlvs.message_state.tagValue] === undefined) {
-			returnObj.log.info(thisLogPrefix + 'Invalid TLV message_state: "' + pduObj.tlvs.message_state.tagValue + '". SeqNr: ' + pduObj.seqNr);
+			log.info('larvitsmpp: lib/session.js: session() - returnObj.handleCmd.deliver_sm() - Invalid TLV message_state: "' + pduObj.tlvs.message_state.tagValue + '". SeqNr: ' + pduObj.seqNr);
 			returnObj.sendReturn(pduObj, 'ESME_RINVTLVSTREAM');
 
 			return;
@@ -544,99 +552,100 @@ function session(options) {
 
 		// TLV receipted_message_id must exist
 		if (pduObj.tlvs.receipted_message_id === undefined) {
-			returnObj.log.info(thisLogPrefix + 'TLV receipted_message_id is missing. SeqNr: ' + pduObj.seqNr);
+			log.info('larvitsmpp: lib/session.js: session() - returnObj.handleCmd.deliver_sm() - TLV receipted_message_id is missing. SeqNr: ' + pduObj.seqNr);
 			returnObj.sendReturn(pduObj, 'ESME_RINVTLVSTREAM');
 
 			return;
 		}
 
-		dlrObj.statusMsg	= defs.constsById.MESSAGE_STATE[pduObj.tlvs.message_state.tagValue];
-		dlrObj.statusId	= pduObj.tlvs.message_state.tagValue;
-		dlrObj.smsId	= pduObj.tlvs.receipted_message_id.tagValue;
+		dlrObj = {
+			'statusMsg': defs.constsById.MESSAGE_STATE[pduObj.tlvs.message_state.tagValue],
+			'statusId':  pduObj.tlvs.message_state.tagValue,
+			'smsId':     pduObj.tlvs.receipted_message_id.tagValue
+		};
 
 		returnObj.emit('dlr', dlrObj, pduObj);
 		returnObj.sendReturn(pduObj);
 	};
 
 	// Enquire link
-	returnObj.handleCmd.enquire_link = function enquire_link(pduObj) {
-		const	thisLogPrefix	= logPrefix + 'enquire_link() - ';
-
-		returnObj.log.silly(thisLogPrefix + 'Enquiring link');
+	returnObj.handleCmd.enquire_link = function(pduObj) {
+		log.silly('larvitsmpp: lib/session.js: session() - enquireLink() - Enquiring link');
 		returnObj.resetEnqLinkTimer();
 		returnObj.sendReturn(pduObj);
 	};
 
 	// Handle incoming submit_sm
-	returnObj.handleCmd.submit_sm = function submit_sm(pduObj) {
-		const	thisLogPrefix	= logPrefix + 'submit_sm() - ',
-			smsObj	= {};
+	returnObj.handleCmd.submit_sm = function(pduObj) {
+		var smsObj = {};
+		        var msgId  = require('uuid').v4();
 
-		returnObj.log.silly(thisLogPrefix + 'ran');
+		log.silly('larvitsmpp: lib/session.js: session() - returnObj.handleCmd.submit_sm() - ran');
 
 		// If esm_class is 0x40 it means this is just a part of a larger message
 		//if (pduObj.params.esm_class === 0x40) {
 		// Fix: esm_class can be combination of bits. We need to extract 0x40 and then compare
 		if ((pduObj.params.esm_class & 0x40) === 0x40) {
-			returnObj.log.debug(thisLogPrefix + 'long sms detected, esm_class 0x40.');
+			log.debug('larvitsmpp: lib/session.js: session() - returnObj.handleCmd.submit_sm() - long sms detected, esm_class 0x40.');
 			returnObj.longSms(pduObj);
 			return; // Long messages should not get handled here at all, so cancel execution here
 		}
 
-		// These are needed for references here and there in functions
-		smsObj.session	= returnObj;
-		smsObj.pduObjs	= [{'pduObj': pduObj}];
-		smsObj.from	= pduObj.params.source_addr;
-		smsObj.to	= pduObj.params.destination_addr;
-		smsObj.submitTime	= new Date();
-		smsObj.message	= pduObj.params.short_message;
-		smsObj.dlr	= Boolean(pduObj.params.registered_delivery);
-		smsObj.sendResp	= smsResp;
-		smsObj.sendDlr	= utils.smsDlr;
-		smsObj.log	= returnObj.log;
+		smsObj = {
+
+			// These are needed for references here and there in functions
+			'session':    returnObj,
+			'pduObjs':    [{'pduObj': pduObj}],
+			'smsId':      msgId,              // <-- ADD THIS LINE
+			'from':       pduObj.params.source_addr,
+			'to':         pduObj.params.destination_addr,
+			'submitTime': new Date(),
+			'message':    pduObj.params.short_message,
+			'dlr':        Boolean(pduObj.params.registered_delivery),
+			'sendResp':   smsResp,
+			'sendDlr':    utils.smsDlr
+		};
 
 		if (pduObj.params.data_coding === 0x10) {
-			smsObj.flash	= true;
+			smsObj.flash = true;
 		}
 
-		returnObj.log.silly(thisLogPrefix + 'Emitting sms object');
+		log.silly('larvitsmpp: lib/session.js: session() - returnObj.handleCmd.submit_sm() - Emitting sms object');
 
 		returnObj.emit('sms', smsObj);
 	};
 
 	// Handle incoming unbind
-	returnObj.handleCmd.unbind = function unbind(pduObj) {
+	returnObj.handleCmd.unbind = function(pduObj) {
 		returnObj.sendReturn(pduObj, 'ESME_ROK', undefined, true);
 	};
 
 	// Dummy, should be extended by serverSession or clientSession
-	returnObj.login = function login() {
-		const	thisLogPrefix	= logPrefix + 'login() - ';
-
-		returnObj.log.info(thisLogPrefix + 'Dummy login function ran, this might be a mistake');
-		returnObj.loggedIn	= true;
+	returnObj.login = function() {
+		log.info('larvitsmpp: lib/session.js: session() - login() - Dummy login function ran, this might be a mistake');
+		returnObj.loggedIn = true;
 	};
 
 	// Dummy method - should be used by serverSession or clientSession
-	returnObj.resetEnqLinkTimer = function resetEnqLinkTimer() {
-		const	thisLogPrefix	= logPrefix + 'resetEnqLinkTimer() - ';
-		returnObj.log.silly(thisLogPrefix + 'Resetting the kill timer');
+	returnObj.resetEnqLinkTimer = function() {
+		log.silly('larvitsmpp: lib/session.js: session() - resetEnqLinkTimer() - Resetting the kill timer');
 	};
 
 	// Unbind this session
-	returnObj.unbind = function unbind() {
+	returnObj.unbind = function() {
 		returnObj.send({
-			'cmdName':	'unbind'
+			'cmdName': 'unbind'
 		}, true);
 	};
 
 	// Setup a data queue in case we only get partial data on the socket
 	// This way we can concatenate them later on
-	returnObj.dataQueue	= new Buffer(0);
+	returnObj.dataQueue = new Buffer(0);
 
 	// Add a 'data' event handler to this instance of socket
-	options.sock.on('data', function (data) {
-		const	thisLogPrefix	= logPrefix + 'sock.on(data) - ';
+	sock.on('data', function(data) {
+		var cmdLength,
+		    pdu;
 
 		// Pass the data along to the returnObj
 		returnObj.emit('data', data);
@@ -644,32 +653,20 @@ function session(options) {
 		// Reset the enquire link timer
 		returnObj.resetEnqLinkTimer();
 
-		returnObj.log.debug(thisLogPrefix + 'Incoming data: ' + data.toString('hex'));
+		log.debug('larvitsmpp: lib/session.js: session() - sock.on(data) - Incoming data: ' + data.toString('hex'));
 
 		// Add this data to the dataQueue for processing
-		returnObj.dataQueue	= Buffer.concat([returnObj.dataQueue, data]);
+		returnObj.dataQueue = Buffer.concat([returnObj.dataQueue, data]);
 
 		// Process queue
 		while (returnObj.dataQueue.length > 4) {
-			const	cmdLength	= parseInt(returnObj.dataQueue.readUInt32BE(0));	// Get this commands length
-
-			let	pdu;
-
-			// Malformed PDU with command length 0
-			if (cmdLength <= 0) {
-				// Since PDU is Malformed we need to discard buffer.
-				returnObj.log.silly(thisLogPrefix + 'Malformed PDU with 0 Length. Discarding buffer.');
-				returnObj.dataQueue	= returnObj.dataQueue.slice(0, returnObj.dataQueue.length);
-
-				// Since PDU is malformed we need to close socket since we cannot trust data from now on.
-				returnObj.closeSocket();
-			}
-
-			returnObj.log.silly(thisLogPrefix + 'Processing ' + cmdLength + ' bytes of data');
+			// Get this commands length
+			cmdLength = parseInt(returnObj.dataQueue.readUInt32BE(0));
+			log.silly('larvitsmpp: lib/session.js: session() - sock.on(data) - Processing ' + cmdLength + ' bytes of data');
 
 			// If there is at least enough bytes in the dataQueue to fill this PDU, do it!
 			if (cmdLength <= returnObj.dataQueue.length) {
-				returnObj.log.silly(thisLogPrefix + 'Full PDU found in dataQueue, processing ' + cmdLength + ' bytes of queue total ' + returnObj.dataQueue.length + ' bytes');
+				log.silly('larvitsmpp: lib/session.js: session() - sock.on(data) - Full PDU found in dataQueue, processing ' + cmdLength + ' bytes of queue total ' + returnObj.dataQueue.length + ' bytes');
 
 				// Slice up the dataQueue buffer to this commands length
 				pdu = returnObj.dataQueue.slice(0, cmdLength);
@@ -679,35 +676,34 @@ function session(options) {
 
 				returnObj.emit('incomingPdu', pdu);
 			} else {
-				returnObj.log.debug(thisLogPrefix + 'Tried to process ' + cmdLength + ' bytes, but only ' + returnObj.dataQueue.length + ' bytes found. Awaiting more data. Current data in queue: ' + returnObj.dataQueue.toString('hex'));
+				log.debug('larvitsmpp: lib/session.js: session() - sock.on(data) - Tried to process ' + cmdLength + ' bytes, but only ' + returnObj.dataQueue.length + ' bytes found. Awaiting more data. Current data in queue: ' + returnObj.dataQueue.toString('hex'));
 
 				break;
 			}
 
 			if (returnObj.dataQueue.length === 0) {
-				returnObj.log.silly(thisLogPrefix + 'All queue handled, breaking while loop.');
+				log.silly('larvitsmpp: lib/session.js: session() - sock.on(data) - All queue handled, breaking while loop.');
 				break;
 			}
 
 			// If the command length is larger than the queue, we need to wait for more data. Stop processing!
 			if (cmdLength > returnObj.dataQueue) {
-				returnObj.log.debug(thisLogPrefix + 'Incomplete PDU found in dataQueue, waiting for more data to continue. Current cmdLength: ' + cmdLength + ' current queue: ' + returnObj.dataQueue.toString('hex'));
+				log.debug('larvitsmpp: lib/session.js: session() - sock.on(data) - Incomplete PDU found in dataQueue, waiting for more data to continue. Current cmdLength: ' + cmdLength + ' current queue: ' + returnObj.dataQueue.toString('hex'));
+
 				break;
 			}
 		}
-	});
+  });
 
 	// Handle incoming Pdu Buffers
-	returnObj.on('incomingPdu', function (pdu) {
-		const	thisLogPrefix	= logPrefix + 'sock.on(incomingPdu) - ';
-
-		utils.pduToObj(pdu, function (err, pduObj) {
+	returnObj.on('incomingPdu', function(pdu) {
+		utils.pduToObj(pdu, function(err, pduObj) {
 			if (err) {
-				returnObj.log.warn(thisLogPrefix + 'Invalid PDU, closing socket.');
+				log.warn('larvitsmpp: lib/session.js: session() - returnObj.on(incomingPdu) - Invalid PDU, closing socket.');
 
 				returnObj.closeSocket();
 			} else {
-				returnObj.log.verbose(thisLogPrefix + 'Incoming PDU parsed. Seqnr: ' + pduObj.seqNr + ' cmd: ' + pduObj.cmdName + ' cmdStatus: ' + pduObj.cmdStatus + ' hex: ' + pdu.toString('hex'));
+				log.verbose('larvitsmpp: lib/session.js: session() - returnObj.on(incomingPdu) - Incoming PDU parsed. Seqnr: ' + pduObj.seqNr + ' cmd: ' + pduObj.cmdName + ' cmdStatus: ' + pduObj.cmdStatus + ' hex: ' + pdu.toString('hex'));
 
 				if (pduObj.isResp()) {
 					// We do this so we can remove the dynamic event listeners to not have a memory leak
@@ -723,23 +719,19 @@ function session(options) {
 	});
 
 	// Add a 'close' event handler to this instance of socket
-	options.sock.on('close', function () {
-		const	thisLogPrefix	= logPrefix + 'sock.on(close) - ';
-
+	sock.on('close', function() {
 		returnObj.emit('close');
 		if (returnObj.enqLinkTimer) {
-			returnObj.log.debug(thisLogPrefix + 'enqLinkTimer found, clearing.');
+			log.debug('larvitsmpp: lib/session.js: session() - sock.on(close) - enqLinkTimer found, clearing.');
 			clearTimeout(returnObj.enqLinkTimer);
 		}
-		returnObj.log.debug(thisLogPrefix + 'socket closed');
+		log.debug('larvitsmpp: lib/session.js: session() - sock.on(close) - socket closed');
 	});
 
-	options.sock.on('error', function () {
-		const	thisLogPrefix	= logPrefix + 'sock.on(error) - ';
-
-		returnObj.log.warn(thisLogPrefix + 'Socket error detected!');
+	sock.on('error', function() {
+		log.warn('larvitsmpp: lib/session.js: session() - sock.on(error) - Socket error detected!');
 		if (returnObj.enqLinkTimer) {
-			returnObj.log.debug(thisLogPrefix + 'enqLinkTimer found, clearing.');
+			log.debug('larvitsmpp: lib/session.js: session() - sock.on(error) - enqLinkTimer found, clearing.');
 			clearTimeout(returnObj.enqLinkTimer);
 		}
 	});

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,47 +1,49 @@
 'use strict';
 
-const	topLogPrefix	= 'larvitsmpp: lib/utils.js: ',
-	LUtils	= require('larvitutils'),
-	lUtils	= new LUtils(),
-	defs	= require(__dirname + '/defs.js');
-
-let	bundleMsgId	= 0;
+var log         = require('winston'),
+    defs        = require('./defs'),
+    bundleMsgId = 0;
 
 /**
- * Calculate cmdLength from object
+ * Calcualte cmdLength from object
  *
- * @param {object} obj
- * @param {function} cb - cb(err, cmdLength)
+ * @param obj obj
+ * @param func callback(err, cmdLength)
  */
-function calcCmdLength(obj, cb) {
-	const	logPrefix	= topLogPrefix + 'calcCmdLength() - ';
-
-	let	cmdLength	= 16;	// All commands are at least 16 octets long
+function calcCmdLength(obj, callback) {
+	var cmdLength = 16, // All commands are at least 16 octets long
+	    err,
+	    param,
+	    paramType,
+	    tlvValue,
+	    tlvName,
+	    tlvDef;
 
 	// Handle params - All command params should always exists, even if they do not contain data.
-	for (const param in defs.cmds[obj.cmdName].params) {
+	for (param in defs.cmds[obj.cmdName].params) {
+
 		// Get the parameter type, int, string, cstring etc.
 		// This is needed so we can calculate length etc
-		const	paramType = defs.cmds[obj.cmdName].params[param].type;
+		paramType = defs.cmds[obj.cmdName].params[param].type;
 
 		if (obj.params[param] === undefined) {
-			obj.params[param]	= paramType.default;
+			obj.params[param] = paramType.default;
 		}
 
 		if (isNaN(paramType.size(obj.params[param]))) {
-			const	err	= new Error('Invalid param value "' + obj.params[param] + '" for param "' + param + '" and command "' + obj.cmdName + '". Is it of the right type?');
-			exports.log.error(logPrefix + err.message);
-			return cb(err);
+			err = new Error('Invalid param value "' + obj.params[param] + '" for param "' + param + '" and command "' + obj.cmdName + '". Is it of the right type?');
+			log.error('larvitsmpp: lib/utils.js: calcCmdLength() - ' + err.message);
+			callback(err);
+			return;
 		}
 
 		cmdLength += paramType.size(obj.params[param]);
 	}
 
 	// TLV params - optional parameters
-	for (const tlvName in obj.tlvs) {
-		const	tlvValue	= obj.tlvs[tlvName].tagValue;
-
-		let	tlvDef	= defs.tlvsById[obj.tlvs[tlvName].tagId];
+	for (tlvName in obj.tlvs) {
+		tlvValue = obj.tlvs[tlvName].tagValue;
+		tlvDef   = defs.tlvsById[obj.tlvs[tlvName].tagId];
 
 		if (tlvDef === undefined) {
 			tlvDef = defs.tlvs.default;
@@ -49,68 +51,79 @@ function calcCmdLength(obj, cb) {
 
 		try {
 			cmdLength += tlvDef.type.size(tlvValue) + 4;
-		} catch (err) {
-			const	manErr	= new Error('Could not get size of TLV parameter "' + tlvName + '" with value "' + tlvValue + '", err: ' + err.message);
-			exports.log.error(logPrefix + manErr.message);
-			return cb(manErr);
+		} catch(e) {
+			err = new Error('Could not get size of TLV parameter "' + tlvName + '" with value "' + tlvValue + '"');
+			log.error('larvitsmpp: lib/utils.js: calcCmdLength() - ' + err.message);
+			callback(err);
+			return;
 		}
 	}
 
-	cb(null, cmdLength);
+	callback(null, cmdLength);
 }
 
 /**
  * Write PDU to buffer
  *
- * @param {object} obj - the PDU object to be written to buffer
- * @param {number} cmdLength - The length of the pdu buffer
- * @param {function} cb - cb(err, buff)
+ * @param obj obj - the PDU object to be written to buffer
+ * @param int cmdLength - The length of the pdu buffer
+ * @param func callback(err, buff)
  */
-function writeBuffer(obj, cmdLength, cb) {
-	const	logPrefix	= topLogPrefix + 'writeBuffer() - ';
+function writeBuffer(obj, cmdLength, callback) {
+	var offset = 16, // Start the offset on the body
+	    buff,
+	    param,
+	    paramType,
+	    paramSize,
+	    tlvId,
+	    tlvName,
+	    tlvValue,
+	    tlvDef,
+	    tlvSize,
+	    err;
 
-	let	offset	= 16, // Start the offset on the body
-		buff;
+	if (isNaN(cmdLength) || cmdLength < 16) {
+		if (isNaN(cmdLength)) {
+			err = new Error('cmdLength is NaN');
+		}
 
-	if (isNaN(cmdLength)) {
-		const	err	= new Error('cmdLength is NaN');
-		exports.log.error(logPrefix + err.message);
-		return cb(err);
-	}
+		if (cmdLength < 16) {
+			err = new Error('cmdLength is less than 16 (' + cmdLength + ')');
+		}
 
-	if (cmdLength < 16) {
-		const	err	= new Error('cmdLength is less than 16 (' + cmdLength + ')');
-		exports.log.error(logPrefix + err.message);
-		return cb(err);
+		log.error('larvitsmpp: lib/utils.js: objToPdu() - writeBuffer() - ' + err.message);
+		callback(err);
+		return;
 	}
 
 	buff = new Buffer(cmdLength);
 
 	// Write PDU header
 	try {
-		buff.writeUInt32BE(cmdLength, 0);	// Command length for the first 4 octets
-		buff.writeUInt32BE(defs.cmds[obj.cmdName].id, 4);	// Command id for the second 4 octets
-		buff.writeUInt32BE(defs.errors[obj.cmdStatus], 8);	// Command status for the third 4 octets
-		buff.writeUInt32BE(obj.seqNr, 12);	// Sequence number as the fourth 4 octets
-	} catch (err) {
-		const	manErr = new Error('Could not write PDU header, catched err: ' + err.message, obj);
-		exports.log.error(logPrefix + manErr.message);
-		return cb(manErr);
+		buff.writeUInt32BE(cmdLength, 0);                  // Command length for the first 4 octets
+		buff.writeUInt32BE(defs.cmds[obj.cmdName].id, 4);  // Command id for the second 4 octets
+		buff.writeUInt32BE(defs.errors[obj.cmdStatus], 8); // Command status for the third 4 octets
+		buff.writeUInt32BE(obj.seqNr, 12);                 // Sequence number as the fourth 4 octets
+	} catch (e) {
+		err = new Error('Could not write PDU header, catched err: ' + e.message, obj);
+		log.error('larvitsmpp: lib/utils.js: writeBuffer() - ' + err.message);
+		callback(err);
+		return;
 	}
 
 	// Cycle through the defs list to make sure the params are in the right order
-	for (const param in defs.cmds[obj.cmdName].params) {
-		const	paramType	= defs.cmds[obj.cmdName].params[param].type,
-			paramSize	= paramType.size(obj.params[param]);
+	for (param in defs.cmds[obj.cmdName].params) {
+		paramType = defs.cmds[obj.cmdName].params[param].type;
+		paramSize = paramType.size(obj.params[param]);
 
 		if (Buffer.isBuffer(obj.params[param])) {
-			exports.log.silly(logPrefix + 'Writing param "' + param + '" with content "' + obj.params[param].toString('hex') + '" and size "' + paramSize + '"');
+			log.silly('larvitsmpp: lib/utils.js: writeBuffer() - Writing param "' + param + '" with content "' + obj.params[param].toString('hex') + '" and size "' + paramSize + '"');
 		} else {
 			if (param === 'sm_length') {
-				exports.log.silly(logPrefix + 'sm_length is calculated by short_message: "' + obj.params.short_message.toString('hex') + '"');
+				log.silly('larvitsmpp: lib/utils.js: writeBuffer() - sm_length is calculated by short_message: "' + obj.params.short_message.toString('hex') + '"');
 			}
 
-			exports.log.silly(logPrefix + 'Writing param "' + param + '" with content "' + obj.params[param] + '"');
+			log.silly('larvitsmpp: lib/utils.js: writeBuffer() - Writing param "' + param + '" with content "' + obj.params[param] + '"');
 		}
 
 		// Write parameter value to buffer using the types method write()
@@ -121,20 +134,18 @@ function writeBuffer(obj, cmdLength, cb) {
 	}
 
 	// Cycle through the tlvs
-	for (const tlvName in obj.tlvs) {
-		const	tlvValue	= obj.tlvs[tlvName].tagValue,
-			tlvId	= obj.tlvs[tlvName].tagId;
-
-		let	tlvDef	= defs.tlvsById[tlvId],
-			tlvSize;
+	for (tlvName in obj.tlvs) {
+		tlvId    = obj.tlvs[tlvName].tagId;
+		tlvValue = obj.tlvs[tlvName].tagValue;
+		tlvDef   = defs.tlvsById[tlvId];
 
 		if (tlvDef === undefined) {
 			tlvDef = defs.tlvs.default;
 		}
 
-		tlvSize	= tlvDef.type.size(tlvValue);
+		tlvSize  = tlvDef.type.size(tlvValue);
 
-		exports.log.silly(logPrefix + 'Writing TLV "' + tlvName + '" offset: ' + offset + ' value: "' + tlvValue + '"');
+		log.silly('larvitsmpp: lib/utils.js: writeBuffer() - Writing TLV "' + tlvName + '" offset: ' + offset + ' value: "' + tlvValue + '"');
 
 		buff.writeUInt16BE(tlvId, offset);
 		buff.writeUInt16BE(tlvSize, offset + 2);
@@ -143,44 +154,50 @@ function writeBuffer(obj, cmdLength, cb) {
 		offset += tlvDef.type.size(tlvValue) + 4;
 	}
 
-	exports.log.silly(logPrefix + 'Complete PDU: "' + buff.toString('hex') + '"');
+	log.silly('larvitsmpp: lib/utils.js: writeBuffer() - Complete PDU: "' + buff.toString('hex') + '"');
 
-	cb(null, buff);
+	callback(null, buff);
 }
 
 /**
  * Decode a short_message
  *
- * @param {buffer} buffer
- * @param {string} encoding 'ASCII', 'LATIN1' or 'UCS2' or hex values
- * @param {number} offset - defaults to 0
- * @return {string} in utf8 format
+ * @param buf buffer
+ * @param str encoding 'ASCII', 'LATIN1' or 'UCS2' or hex values
+ * @param int offset - defaults to 0
+ * @return str in utf8 format
  */
 function decodeMsg(buffer, encoding, offset) {
-	const	logPrefix	= topLogPrefix + 'decodeMsg() - ';
+	var checkEnc;
 
 	if (offset === undefined) {
 		offset = 0;
 	}
+	if (encoding.toString() === '4') {
+        // Handle binary encoding
+        	return buffer.slice(offset);
+   	}
+		log.info("hy"+encoding+"hy");
+		console.log("Encoding value: ", encoding, "Type: ", typeof encoding);
 
-	for (const checkEnc in defs.consts.ENCODING) {
+	for (checkEnc in defs.consts.ENCODING) {
 		if (parseInt(encoding) === defs.consts.ENCODING[checkEnc] || encoding === checkEnc) {
 			encoding = checkEnc;
 		}
 	}
 
 	if (defs.encodings[encoding] === undefined) {
-		exports.log.info(logPrefix + 'Invalid encoding "' + encoding + '" given. Falling back to ASCII (0x01).');
+		log.info('larvitsmpp: lib/utils.js: decodeMsg() - Invalid encoding "' + encoding + '" given. Falling back to ASCII (0x01).');
 		encoding = 'ASCII';
 	}
 
-	exports.log.debug(logPrefix + 'Decoding msg. Encoding: "' + encoding + '" offset: "' + offset + '" buffer: "' + buffer.toString('hex') + '"');
+	log.debug('larvitsmpp: lib/utils.js: decodeMsg() - Decoding msg. Encoding: "' + encoding + '" offset: "' + offset + '" buffer: "' + buffer.toString('hex') + '"');
 
 	return defs.encodings[encoding].decode(buffer.slice(offset));
 }
 
 function encodeMsg(str) {
-	const	encoding	= defs.encodings.detect(str);
+	var encoding = defs.encodings.detect(str);
 
 	return defs.encodings[encoding].encode(str);
 }
@@ -188,106 +205,109 @@ function encodeMsg(str) {
 /**
  * Transforms a PDU to an object
  *
- * @param {buffer} pdu
- * @param {boolean} stupidNullByte - Define if the short_message should be followed by a stupid NULL byte - will be auto resolved if left undefined
- * @param {function} cb - cb(err, obj)
+ * @param buf pdu
+ * @param bol stupidNullByte - Define if the short_message should be followed by a stupid NULL byte - will be auto resolved if left undefined
+ * @param func callback(err, obj)
  */
-function pduToObj(pdu, stupidNullByte, cb) {
-	const	logPrefix	= topLogPrefix + 'pduToObj() - ',
-		retObj	= {'params': {}, 'tlvs': {}};
-
-	let	offset	= 16,	// 0-15 is the header, so the body starts at 16
-		command;
+function pduToObj(pdu, stupidNullByte, callback) {
+	var retObj = {'params': {}, 'tlvs': {}},
+	    err    = null,
+	    offset,
+	    command,
+	    param,
+	    tlvCmdId,
+	    tlvLength,
+	    tlvValue,
+	    paramSize;
 
 	if (typeof stupidNullByte === 'function') {
-		cb	= stupidNullByte;
-		stupidNullByte	= undefined;
+		callback       = stupidNullByte;
+		stupidNullByte = undefined;
 	}
 
 	// Returns true if this PDU is a response to another PDU
-	retObj.isResp = function () {
+	retObj.isResp = function() {
 		return ! ! (this.cmdId & 0x80000000);
 	};
 
-	exports.log.silly(logPrefix + 'Decoding PDU to Obj. PDU buff in hex: ' + pdu.toString('hex'));
+	log.silly('larvitsmpp: lib/utils.js: pduToObj() - Decoding PDU to Obj. PDU buff in hex: ' + pdu.toString('hex'));
 
 	if (pdu.length < 16) {
-		const	err	= new Error('PDU is to small, minimum size is 16, given size is ' + pdu.length);
-		exports.log.warn(logPrefix + '' + err.message);
-		return cb(err);
+		err = new Error('PDU is to small, minimum size is 16, given size is ' + pdu.length);
+		log.warn('larvitsmpp: lib/utils.js: pduToObj() - ' + err.message);
+
+		callback(err);
+		return;
 	}
 
 	// Read the PDU Header
-	retObj.cmdLength	= parseInt(pdu.readUInt32BE(0));
-	retObj.cmdId	= parseInt(pdu.readUInt32BE(4));
-	retObj.cmdStatus	= defs.errorsById[parseInt(pdu.readUInt32BE(8))];
-	retObj.seqNr	= parseInt(pdu.readUInt32BE(12));
+	retObj.cmdLength = parseInt(pdu.readUInt32BE(0));
+	retObj.cmdId     = parseInt(pdu.readUInt32BE(4));
+	retObj.cmdStatus = defs.errorsById[parseInt(pdu.readUInt32BE(8))];
+	retObj.seqNr     = parseInt(pdu.readUInt32BE(12));
 
 	// Lookup the command id in the definitions
 	if (defs.cmdsById[retObj.cmdId] === undefined) {
-		const	err	= new Error('Unknown PDU command id: ' + retObj.cmdId + ' PDU buff in hex: ' + pdu.toString('hex'));
-		exports.log.warn(logPrefix + '' + err.message);
-		return cb(err);
+		err = new Error('Unknown PDU command id: ' + retObj.cmdId + ' PDU buff in hex: ' + pdu.toString('hex'));
 	}
 
 	if (isNaN(retObj.seqNr)) {
-		const	err	= new Error('Invalid seqNr, is not an interger: "' + retObj.seqNr + '"');
-		exports.log.warn(logPrefix + '' + err.message);
-		return cb(err);
+		err = new Error('Invalid seqNr, is not an interger: "' + retObj.seqNr + '"');
+	} else if (retObj.seqNr > 2147483646) {
+		err = new Error('Invalid seqNr, maximum size of 2147483646 (0x7fffffff) exceeded.');
 	}
 
-	if (retObj.seqNr > 2147483646) {
-		const	err	= new Error('Invalid seqNr, maximum size of 2147483646 (0x7fffffff) exceeded.');
-		exports.log.warn(logPrefix + '' + err.message);
-		return cb(err);
+	// If error is found, do not proceed with execution
+	if (err !== null) {
+		log.warn('larvitsmpp: lib/utils.js: pduToObj() - ' + err.message);
+		callback(err);
+		return;
 	}
 
-	command	= defs.cmdsById[retObj.cmdId];
-	retObj.cmdName	= command.command;
+	command        = defs.cmdsById[retObj.cmdId];
+	retObj.cmdName = command.command;
 
 	// Get all parameters from the body that should exists with this command
-	for (const param in command.params) {
+	offset = 16; // 0-15 is the header, so the body starts at 16
+	for (param in command.params) {
 
 		// Get the parameter value by using the definition type read() function
 		try {
-			let	paramSize;
+			retObj.params[param] = command.params[param].type.read(pdu, offset, retObj.params.sm_length);
+			paramSize            = command.params[param].type.size(retObj.params[param]);
 
-			retObj.params[param]	= command.params[param].type.read(pdu, offset, retObj.params.sm_length);
-			paramSize	= command.params[param].type.size(retObj.params[param]);
-
-			exports.log.silly(logPrefix + 'Reading param "' + param + '" at offset ' + offset + ' with calculated size: ' + paramSize + ' content in hex: ' + pdu.slice(offset, offset + paramSize).toString('hex'));
+			log.silly('larvitsmpp: lib/utils.js: pduToObj() - Reading param "' + param + '" at offset ' + offset + ' with calculated size: ' + paramSize + ' content in hex: ' + pdu.slice(offset, offset + paramSize).toString('hex'));
 			if (param === 'short_message') {
 				// Check if we have a trailing NULL octet after the short_message. Some idiot thought that would be a good idea
 				// in some implementations, so we need to account for that.
 				if (stupidNullByte === true) {
-					exports.log.silly(logPrefix + 'stupidNullByte is set, so short_message is followed by a NULL octet, increase paramSize one extra to account for that');
+					log.silly('larvitsmpp: lib/utils.js: pduToObj() - stupidNullByte is set, so short_message is followed by a NULL octet, increase paramSize one extra to account for that');
 					paramSize ++;
 				}
 			}
 
 			// Increase the offset by the current params length
 			offset += paramSize;
-		} catch (err) {
-			const	manErr	= new Error('Failed to read param "' + param + '", err: ' + err.message);
-			exports.log.error(logPrefix + '' + manErr.message);
-			return cb(err);
+		} catch (e) {
+			err = new Error('Failed to read param "' + param + '": ' + e.message);
+			log.error('larvitsmpp: lib/utils.js: pduToObj() - ' + err.message);
+			callback(err);
+
+			return;
 		}
 	}
 
 	// If the length is greater than the current offset, there must be TLVs - resolve them!
 	// The minimal size for a TLV is its head, 4 octets
 	while ((offset + 4) < retObj.cmdLength) {
-		let	tlvLength,
-			tlvCmdId,
-			tlvValue;
-
 		try {
-			tlvCmdId	= pdu.readInt16BE(offset);
-			tlvLength	= pdu.readInt16BE(offset + 2);
-		} catch (err) {
-			const	manErr	= new Error('Unable to read TLV at offset "' + offset + '", given cmdLength: "' + retObj.cmdLength + '" pdu: ' + pdu.toString('hex') + ', err: ' + err.message);
-			exports.log.error(logPrefix + '' + manErr.message);
-			return cb(manErr);
+			tlvCmdId  = pdu.readInt16BE(offset);
+			tlvLength = pdu.readInt16BE(offset + 2);
+		} catch (e) {
+			err = new Error('Unable to read TLV at offset "' + offset + '", given cmdLength: "' + retObj.cmdLength + '" pdu: ' + pdu.toString('hex'));
+			log.error('larvitsmpp: lib/utils.js: pduToObj() - ' + err.message);
+			callback(err);
+			return;
 		}
 
 		if (defs.tlvsById[tlvCmdId] === undefined) {
@@ -299,7 +319,7 @@ function pduToObj(pdu, stupidNullByte, cb) {
 				'tagValue': tlvValue
 			};
 
-			exports.log.verbose(logPrefix + 'Unknown TLV found. Hex ID: ' + tlvCmdId.toString(16) + ' length: ' + tlvLength + ' hex value: ' + tlvValue);
+			log.verbose('larvitsmpp: lib/utils.js: pduToObj() - Unknown TLV found. Hex ID: ' + tlvCmdId.toString(16) + ' length: ' + tlvLength + ' hex value: ' + tlvValue);
 		} else {
 			tlvValue = defs.tlvsById[tlvCmdId].type.read(pdu, offset + 4, tlvLength);
 
@@ -308,192 +328,213 @@ function pduToObj(pdu, stupidNullByte, cb) {
 			}
 
 			retObj.tlvs[defs.tlvsById[tlvCmdId].tag] = {
-				'tagId':	tlvCmdId,
-				'tagName':	defs.tlvsById[tlvCmdId].tag,
-				'tagValue':	tlvValue
+				'tagId': tlvCmdId,
+				'tagName': defs.tlvsById[tlvCmdId].tag,
+				'tagValue': tlvValue
 			};
 
-			exports.log.silly(logPrefix + 'TLV found: "' + defs.tlvsById[tlvCmdId].tag + '" ID: "' + tlvCmdId + '" value: "' + tlvValue + '"');
+			log.silly('larvitsmpp: lib/utils.js: pduToObj() - TLV found: "' + defs.tlvsById[tlvCmdId].tag + '" ID: "' + tlvCmdId + '" value: "' + tlvValue + '"');
 		}
 
 		offset = offset + 4 + tlvLength;
 	}
 
 	if (offset !== retObj.cmdLength && stupidNullByte === undefined) {
-		exports.log.verbose(logPrefix + 'Offset (' + offset + ') !== cmdLength (' + retObj.cmdLength + ') for seqNr: ' + retObj.seqNr + ' - retry with the stupid NULL byte for short_message');
+		log.verbose('larvitsmpp: lib/utils.js: pduToObj() - Offset (' + offset + ') !== cmdLength (' + retObj.cmdLength + ') for seqNr: ' + retObj.seqNr + ' - retry with the stupid NULL byte for short_message');
 
-		return pduToObj(pdu, true, cb);
+		pduToObj(pdu, true, callback);
+		return;
 	}
 
 	if (offset !== retObj.cmdLength) {
-		exports.log.warn(logPrefix + 'Offset (' + offset + ') !== cmdLength (' + retObj.cmdLength + ') for seqNr: ' + retObj.seqNr);
+		log.warn('larvitsmpp: lib/utils.js: pduToObj() - Offset (' + offset + ') !== cmdLength (' + retObj.cmdLength + ') for seqNr: ' + retObj.seqNr);
 	}
 
 	// Decode the short message if it is set and esm_class is 0
 	// The esm_class 0x40 (64 int) means the short_message have a UDH
 	// Thats why we return the short_message as a buffer
 	if (retObj.params.short_message !== undefined && (retObj.params.esm_class & 0x40) !== 0x40) {
-		retObj.params.short_message	= decodeMsg(retObj.params.short_message, retObj.params.data_coding);
+		retObj.params.short_message = decodeMsg(retObj.params.short_message, retObj.params.data_coding);
 	}
 
-	exports.log.debug(logPrefix + 'Complete decoded PDU: ' + JSON.stringify(retObj));
+	log.debug('larvitsmpp: lib/utils.js: pduToObj() - Complete decoded PDU: ' + JSON.stringify(retObj));
 
-	cb(null, retObj);
+	callback(null, retObj);
 }
 
 /**
  * Transform an object to a PDU
  *
- * @param {object} obj - example {'cmdName': 'bind_transceiver_resp', 'cmdStatus': 'ESME_ROK', 'seqNr': 2} - to add parameters add a key 'params' as object
- * @param {function} cb - cb(err, pdu)
+ * @param obj obj - example {'cmdName': 'bind_transceiver_resp', 'cmdStatus': 'ESME_ROK', 'seqNr': 2} - to add parameters add a key 'params' as object
+ * @param func callback(err, pdu)
  */
-function objToPdu(obj, cb) {
-	const	logPrefix	= topLogPrefix + 'objToPdu() - ',
-		seqNr	= parseInt(obj.seqNr);
+function objToPdu(obj, callback) {
+	var err = null,
+	    shortMsg,
+	    seqNr;
 
 	// Check so the command is ok
 	if (defs.cmds[obj.cmdName] === undefined) {
-		const	err	= new Error('Invalid cmdName: "' + obj.cmdName + '"');
-		exports.log.warn(logPrefix + err.message);
-		return cb(err);
+		err = new Error('larvitsmpp: lib/utils.js: objToPdu() - Invalid cmdName: "' + obj.cmdName + '"');
 	}
 
 	// Check so the command status is ok
 	if (obj.cmdStatus === undefined) {
-		obj.cmdStatus	= 'ESME_ROK';	// Default to OK
+		// Default to OK
+		obj.cmdStatus = 'ESME_ROK';
 	}
 
 	if (defs.errors[obj.cmdStatus] === undefined) {
-		const	err	= new Error('Invalid cmdStatus: "' + obj.cmdStatus + '"');
-		exports.log.warn(logPrefix + err.message);
-		return cb(err);
+		err = new Error('larvitsmpp: lib/utils.js: objToPdu() - Invalid cmdStatus: "' + obj.cmdStatus + '"');
 	}
 
 	// Check so seqNr is ok
+	seqNr = parseInt(obj.seqNr);
 	if (isNaN(seqNr)) {
-		const	err	= new Error('Invalid seqNr, is not an interger: "' + obj.seqNr + '"');
-		exports.log.warn(logPrefix + err.message);
-		return cb(err);
+		err = new Error('larvitsmpp: lib/utils.js: objToPdu() - Invalid seqNr, is not an interger: "' + obj.seqNr + '"');
+	} else if (seqNr > 2147483646) {
+		err = new Error('larvitsmpp: lib/utils.js: objToPdu() - Invalid seqNr, maximum size of 2147483646 (0x7fffffff) exceeded.');
 	}
 
-	if (seqNr > 2147483646) {
-		const	err	= new Error('Invalid seqNr, maximum size of 2147483646 (0x7fffffff) exceeded.');
-		exports.log.warn(logPrefix + err.message);
-		return cb(err);
+	// If error is found, do not proceed with execution
+	if (err !== null) {
+		log.warn(err.message);
+		callback(err);
+		return;
 	}
 
 	// Params must be an object
 	if (obj.params === undefined) {
-		obj.params	= {};
+		obj.params = {};
 	}
 
 	// If param "short_message" exists, encode it and set parameter "data_coding" accordingly
 	if (obj.params.short_message !== undefined && ! Buffer.isBuffer(obj.params.short_message)) {
-		let	shortMsg;
 
 		// Detect encoding if is not set already
 		if (obj.params.data_coding === undefined) {
 			obj.params.data_coding = defs.encodings.detect(obj.params.short_message);
 
-			exports.log.silly(logPrefix + 'data_coding "' + obj.params.data_coding + '" detected');
+			log.silly('larvitsmpp: lib/utils.js: objToPdu() - data_coding "' + obj.params.data_coding + '" detected');
 
 			// Now set the hex value
-			obj.params.data_coding	= defs.consts.ENCODING[obj.params.data_coding];
+			obj.params.data_coding = defs.consts.ENCODING[obj.params.data_coding];
 		}
 
 		// Acutally encode the string
-		shortMsg	= obj.params.short_message;
-		obj.params.short_message	= encodeMsg(obj.params.short_message);
-		obj.params.sm_length	= obj.params.short_message.length;
-		exports.log.silly(logPrefix + 'Encoding message "' + shortMsg + '" to "' + obj.params.short_message.toString('hex') + '"');
+		shortMsg                 = obj.params.short_message;
+		obj.params.short_message = encodeMsg(obj.params.short_message);
+
+		obj.params.sm_length     = obj.params.short_message.length;
+		log.silly('larvitsmpp: lib/utils.js: objToPdu() - encoding message "' + shortMsg + '" to "' + obj.params.short_message.toString('hex') + '"');
 	}
 
-	exports.log.debug(logPrefix + 'Complete object to encode: ' + JSON.stringify(obj));
+	log.debug('larvitsmpp: lib/utils.js: objToPdu() - Complete object to encode: ' + JSON.stringify(obj));
 
-	calcCmdLength(obj, function (err, cmdLength) {
-		if (err) return cb(err);
+	calcCmdLength(obj, function(err, cmdLength) {
+		if (err) {
+			callback(err);
+			return;
+		}
 
-		writeBuffer(obj, cmdLength, cb);
+		writeBuffer(obj, cmdLength, callback);
 	});
 }
 
 /**
  * Create a PDU as a return to another PDU
  *
- * @param {object|buffer} pdu
- * @param {string} status - see list at defs.errors - defaults to 'ESME_ROK' - no error (OPTIONAL)
- * @param {object} [params]
- * @param {object} [tlvs]
- * @param {function} [cb(err, pduBuffer)]
+ * @param obj or buf pdu
+ * @param str status - see list at defs.errors - defaults to 'ESME_ROK' - no error (OPTIONAL)
+ * @param obj params (OPTIONAL)
+ * @param obj tlvs (OPTIONAL)
+ * @param func callback(err, pduBuffer) (OPTIONAL)
  */
-function pduReturn(pdu, status, params, tlvs, cb) {
-	const	logPrefix	= topLogPrefix + 'pduReturn() - ',
-		retPdu = {};
-
-	let	err	= null;
+function pduReturn(pdu, status, params, tlvs, callback) {
+	var err    = null,
+	    retPdu = {},
+	    param;
 
 	if (Buffer.isBuffer(pdu)) {
-		exports.log.silly(logPrefix + 'Ran with pdu as buffer, run pduToObj() and retry');
+		log.silly('larvitsmpp: lib/utils.js: pduReturn() - ran with pdu as buffer, run pduToObj() and retry');
 
-		pduToObj(pdu, function (err, pduObj) {
-			if (err) return cb(err);
+		pduToObj(pdu, function(err, pduObj) {
+			if (err) {
+				callback(err);
+				return;
+			}
 
-			pduReturn(pduObj, status, params, tlvs, cb);
+			pduReturn(pduObj, status, params, tlvs, callback);
 		});
 		return;
 	}
 
-	exports.log.silly(logPrefix + 'ran');
+	log.silly('larvitsmpp: lib/utils.js: pduReturn() - ran');
 
 	if (typeof tlvs === 'function') {
-		cb	= tlvs;
-		tlvs	= undefined;
+		callback = tlvs;
+		tlvs     = undefined;
 	}
 
 	if (typeof params === 'function') {
-		cb	= params;
-		params	= {};
-		tlvs	= undefined;
+		callback = params;
+		params   = {};
+		tlvs     = undefined;
 	}
 
 	if (typeof status === 'function') {
-		cb	= status;
-		status	= 'ESME_ROK';
-		params	= {};
-		tlvs	= undefined;
+		callback = status;
+		status   = 'ESME_ROK';
+		params   = {};
+		tlvs     = undefined;
 	}
 
 	if (status === undefined) {
-		status	= 'ESME_ROK';
+		status = 'ESME_ROK';
 	}
 
-	if (cb === undefined) {
-		cb	= function () {};
+	if (callback === undefined) {
+		callback = function() {};
 	}
 
 	if (params === undefined) {
-		params	= {};
+		params = {};
 	}
 
-	if (pdu	=== undefined)		err = new Error('PDU is undefined, cannot create response PDU');
-	if (pdu.cmdName	=== undefined)		err = new Error('pdu.cmdName is undefined, cannot create response PDU');
-	if (pdu.seqNr	=== undefined)		err = new Error('pdu.seqNr is undefined, cannot create response PDU');
-	if (err	=== null && defs.errors[status]	=== undefined)	err = new Error('Invalid status: "' + status + '"');
-	if (err	=== null && defs.cmds[pdu.cmdName + '_resp']	=== undefined)	err = new Error('This command does not have a response listed. Given command: "' + pdu.cmdName + '"');
+	if (pdu === undefined) {
+		err = new Error('larvitsmpp: lib/utils.js: pduReturn() - PDU is undefined, cannot create response PDU');
+	}
+
+	if (pdu.cmdName === undefined) {
+		err = new Error('larvitsmpp: lib/utils.js: pduReturn() - pdu.cmdName is undefined, cannot create response PDU');
+	}
+
+	if (pdu.seqNr === undefined) {
+		err = new Error('larvitsmpp: lib/utils.js: pduReturn() - pdu.seqNr is undefined, cannot create response PDU');
+	}
+
+	if (err === null && defs.errors[status] === undefined) {
+		err = new Error('larvitsmpp: lib/utils.js: pduReturn() - Invalid status: "' + status + '"');
+	}
+
+	if (err === null && defs.cmds[pdu.cmdName + '_resp'] === undefined) {
+		err = new Error('larvitsmpp: lib/utils.js: pduReturn() - This command does not have a response listed. Given command: "' + pdu.cmdName + '"');
+	}
 
 	if (err !== null) {
-		exports.log.warn(logPrefix + err.message);
-		return cb(err);
+		log.warn(err.message);
+		callback(err);
+		return;
 	}
 
-	retPdu.cmdName	= pdu.cmdName + '_resp';
-	retPdu.cmdStatus	= status;
-	retPdu.seqNr	= pdu.seqNr;
-	retPdu.params	= params;
-	retPdu.tlvs	= tlvs;
+	retPdu.cmdName   = pdu.cmdName + '_resp';
+	retPdu.cmdStatus = status;
+	retPdu.seqNr     = pdu.seqNr;
+	retPdu.params    = params;
+	retPdu.tlvs      = tlvs;
 
 	// Populate parameters that should exist in the response
-	for (const param in defs.cmds[pdu.cmdName + '_resp'].params) {
+	for (param in defs.cmds[pdu.cmdName + '_resp'].params) {
 
 		// Do not override the manually supplied parameters
 		if (retPdu.params[param] === undefined) {
@@ -501,17 +542,19 @@ function pduReturn(pdu, status, params, tlvs, cb) {
 		}
 	}
 
-	objToPdu(retPdu, cb);
+	objToPdu(retPdu, function(err, retPdu) {
+		callback(err, retPdu);
+	});
 }
 
 /**
  * Format a js date object as ugly SMPP date format
  *
- * @param {object} jsDateObj
- * @return {string}
+ * @param obj jsDateObj
+ * @return str
  */
 function smppDate(jsDateObj) {
-	let	uglyStr	= '';
+	var uglyStr = '';
 
 	uglyStr += jsDateObj.getFullYear().toString().substring(2);
 
@@ -545,8 +588,8 @@ function smppDate(jsDateObj) {
 /**
  * Calculate bitCount of short_message
  *
- * @param {string} msg
- * @param {string} encoding - Force encoding ASCII or UCS2 (OPTIONAL)
+ * @param str msg
+ * @param str encoding - Force encoding ASCII or UCS2 (OPTIONAL)
  * @return integer
  */
 function bitCount(msg, encoding) {
@@ -564,25 +607,25 @@ function bitCount(msg, encoding) {
 /**
  * Split a message into multiple messages
  *
- * @param {string} msg
- * @param {string} encoding - Force encoding ASCII or UCS2 (OPTIONAL)
+ * @param str msg
+ * @param str encoding - Force encoding ASCII or UCS2 (OPTIONAL)
  * @return array of buffers
  */
 function splitMsg(msg, encoding) {
-	const	resolvedEncoding	= encoding || defs.encodings.detect(msg),
-		totBitCount	= bitCount(msg, resolvedEncoding),
-		logPrefix	= topLogPrefix + 'splitMsg() - ',
-		msgs	= [];
-
-	let	msgPart     = '',
-		partCharLimit,
-		i2;
+	var msgPart     = '',
+	    msgs        = [],
+	    encoding    = encoding || defs.encodings.detect(msg),
+	    totBitCount = bitCount(msg, encoding),
+	    udh,
+	    i,
+	    i2,
+	    partCharLimit;
 
 	// A single message could contain up to 1120 bits
 	// Return directly if the message fits into that
 	if (totBitCount < 1121) {
-		exports.log.silly(logPrefix + 'bitCount below 1121 (' + totBitCount + ') return only one part');
-		return [defs.encodings[resolvedEncoding].encode(msg)];
+		log.silly('larvitsmpp: lib/utils.js: splitMsg() - bitCount below 1121 (' + totBitCount + ') return only one part');
+		return [defs.encodings[encoding].encode(msg)];
 	}
 
 	bundleMsgId ++; // This will identify this message "bundle"
@@ -591,16 +634,17 @@ function splitMsg(msg, encoding) {
 		bundleMsgId = 1;
 	}
 
-	exports.log.silly(logPrefix + 'bundleMsgId set to ' + bundleMsgId);
+	log.silly('larvitsmpp: lib/utils.js: splitMsg() - bundleMsgId set to ' + bundleMsgId);
 
-	if (resolvedEncoding === 'ASCII') {
+	if (encoding === 'ASCII') {
 		partCharLimit = 153;
 	} else {
 		partCharLimit = 67;
 	}
 
-	i2	= 0;
-	for (let i = 0; msg[i] !== undefined; i ++) {
+	i  = 0;
+	i2 = 0;
+	while (msg[i] !== undefined) {
 		msgPart += msg[i];
 
 		i2 ++;
@@ -612,7 +656,7 @@ function splitMsg(msg, encoding) {
 			i2 = 0;
 
 			// Add this msgPart minus the last character to the msgs array as an encoded buffer
-			msgs.push(defs.encodings[resolvedEncoding].encode(msgPart.slice(0, - 1)));
+			msgs.push(defs.encodings[encoding].encode(msgPart.slice(0, - 1)));
 
 			// Reset msgPart
 			msgPart = '';
@@ -620,24 +664,30 @@ function splitMsg(msg, encoding) {
 			// Put i back one to account for the last character we removed from the msgPart
 			i --;
 		}
+
+		i ++;
 	}
 
 	// Add the last msgPart to the msgs array
-	msgs.push(defs.encodings[resolvedEncoding].encode(msgPart));
+	msgs.push(defs.encodings[encoding].encode(msgPart));
 
 	// Add the UDH (http://en.wikipedia.org/wiki/Concatenated_SMS)
-	for (let i = 0; msgs[i] !== undefined; i ++) {
+	i = 0;
+	while (msgs[i] !== undefined) {
+
 		// Create the UDH buffer
-		const udh = new Buffer([
-			0x05,	// Length of User Data Header, in this case 05.
-			0x00,	// Information Element Identifier, equal to 00 (Concatenated short messages, 8-bit reference number)
-			0x03,	// Length of the header, excluding the first two fields; equal to 03
-			bundleMsgId,	// CSMS reference number, must be same for all the SMS parts in the CSMS
-			msgs.length,	// Total number of parts. The value shall remain constant for every short message which makes up the concatenated short message. If the value is zero then the receiving entity shall ignore the whole information element
-			i + 1	// This part's number in the sequence. The value shall start at 1 and increment for every short message which makes up the concatenated short message.
+		udh = new Buffer([
+			0x05,        // Length of User Data Header, in this case 05.
+			0x00,        // Information Element Identifier, equal to 00 (Concatenated short messages, 8-bit reference number)
+			0x03,        // Length of the header, excluding the first two fields; equal to 03
+			bundleMsgId, // CSMS reference number, must be same for all the SMS parts in the CSMS
+			msgs.length, // Total number of parts. The value shall remain constant for every short message which makes up the concatenated short message. If the value is zero then the receiving entity shall ignore the whole information element
+			i + 1        // This part's number in the sequence. The value shall start at 1 and increment for every short message which makes up the concatenated short message.
 		]);
 
-		msgs[i]	= Buffer.concat([udh, msgs[i]]);
+		msgs[i] = Buffer.concat([udh, msgs[i]]);
+
+		i ++;
 	}
 
 	return msgs;
@@ -647,80 +697,84 @@ function splitMsg(msg, encoding) {
  * Send a dlr to an sms
  * This must be called from an sms object context
  *
- * @param {string} status - see list at defs.consts.MESSAGE_STATE - defaults to 'DELIVERED'
- * @param {function} cb - cb(err, retPdu, dlrPduObj)
+ * @param str status - see list at defs.consts.MESSAGE_STATE - defaults to 'DELIVERED'
+ * @param func callback(err, retPdu, dlrPduObj)
  */
-function smsDlr(status, cb) {
-	const	logPrefix	= topLogPrefix + 'smsDlr() - ',
-		dlrPduObj	= {},
-		sms	= this;
-
-	let	shortMessage	= 'id:' + sms.smsId + ' sub:001 ';
+function smsDlr(status, callback) {
+	var shortMessage,
+	    dlrPduObj,
+	    err,
+	    sms = this;
 
 	if (typeof status === 'function') {
-		cb	= status;
-		status	= undefined;
+		callback = status;
+		status   = undefined;
 	}
 
 	if (status === undefined || status === true || status === 2 || status === 'true') {
-		status	= 2;
+		status = 2;
 	} else if (defs.consts.MESSAGE_STATE[status] !== undefined) {
-		status	= defs.consts.MESSAGE_STATE[status];
+		status = defs.consts.MESSAGE_STATE[status];
 	} else if (defs.constsById.MESSAGE_STATE[status]) {
-		status	= parseInt(status);
+		status = parseInt(status);
 	} else {
-		status	= 5; // UNDELIVERABLE
+		status = 2; // UNDELIVERABLE
 	}
 
-	if (typeof cb !== 'function') {
-		cb = function () {};
+	if (typeof callback !== 'function') {
+		callback = function() {};
 	}
 
 	if (sms.smsId === undefined) {
-		const	err	= new Error('Trying to send DLR with no smsId.');
-		exports.log.warn(logPrefix + err.message);
-		return cb(err);
+		err = new Error('Trying to send DLR with no smsId.');
+		log.warn('larvitsmpp: lib/utils.js: smsDlr() - ' + err.message);
+		callback(err);
+		return;
 	}
+
+	shortMessage = 'id:' + sms.smsId + ' sub:001 ';
 
 	if (status === 2) {
-		shortMessage	+= 'dlvrd:1 ';
+		shortMessage += 'dlvrd:1 ';
 	} else {
-		shortMessage	+= 'dlvrd:0 ';
+		shortMessage += 'dlvrd:0 ';
 	}
 
-	shortMessage	+= 'submit date:' + smppDate(sms.submitTime);
-	shortMessage	+= ' done date:' + smppDate(new Date());
+	shortMessage += 'submit date:' + smppDate(sms.submitTime);
+	shortMessage += ' done date:' + smppDate(new Date());
 
 	if (status === 2) {
-		shortMessage	+= ' stat:DELIVRD err:0 text:xxx';
+		shortMessage += ' stat:DELIVRD err:000';
 	} else {
-		shortMessage	+= ' stat:UNDELIVERABLE err:1 text:xxx';
+		shortMessage += ' stat:UNDELIV err:001';
 	}
 
-	exports.log.verbose(logPrefix	+ 'Sending DLR message: "' + shortMessage + '"');
+	log.verbose('larvitsmpp: lib/utils.js: smsDlr() - Sending DLR message: "' + shortMessage + '"');
 
-	dlrPduObj.cmdName	= 'deliver_sm';
-	dlrPduObj.params = {
-		'source_addr':	sms.from,
-		'destination_addr':	sms.to,
-		'esm_class':	4,
-		'short_message':	shortMessage
-	};
-	dlrPduObj.tlvs = {
-		'receipted_message_id': {
-			'tagId':	0x001E,
-			'tagName':	'receipted_message_id',
-			'tagValue':	sms.smsId
+	dlrPduObj = {
+		'cmdName': 'deliver_sm',
+		'params': {
+			'source_addr': sms.from,
+			'destination_addr': sms.to,
+			'esm_class': 4,
+			'short_message': shortMessage
 		},
-		'message_state': {
-			'tagId':	0x0427,
-			'tagName':	'message_state',
-			'tagValue':	status
+		'tlvs': {
+			'receipted_message_id': {
+				'tagId': 0x001E,
+				'tagName': 'receipted_message_id',
+				'tagValue': sms.smsId
+			},
+			'message_state': {
+				'tagId': 0x0427,
+				'tagName': 'message_state',
+				'tagValue': status
+			}
 		}
 	};
 
-	sms.session.send(dlrPduObj, false, function (err, retPdu) {
-		cb(err, retPdu, dlrPduObj);
+	sms.session.send(dlrPduObj, false, function(err, retPdu) {
+		callback(err, retPdu, dlrPduObj);
 	});
 }
 
@@ -734,4 +788,3 @@ exports.smppDate  = smppDate;
 exports.bitCount  = bitCount;
 exports.splitMsg  = splitMsg;
 exports.smsDlr    = smsDlr;
-exports.log       = new lUtils.Log();

--- a/test/app.js
+++ b/test/app.js
@@ -1,0 +1,134 @@
+var larvitsmpp  = require('./larvitsmpp');
+var request     =  require('request');
+var urlencode   = require('urlencode');
+var mysql       = require('mysql');
+var moment      = require('moment');
+var connection = mysql.createConnection({
+        host     : 'host_IP',
+        user     : '-',
+        password : '-',
+        database : '-'
+});
+
+process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
+var redis = require("redis"),
+        client = redis.createClient('6379','host-IP');
+var status_mnp = 0;
+var balance = 0;
+var number = 0;
+var currentTime = moment().format('YYYY-MM-DD HH:mm:ss');
+var log = require('bunyan').createLogger({
+        name: 'ITS SMPP',
+        streams: [{
+                path: "/var/log/kannel/access_premium.log",
+        }]
+})
+    defs        = require('./lib/defs');
+
+
+function checkuserpass(username, password, callback) {
+         if (username === 'directufone' && password === '6790') {
+                callback(null, true, {'username': 'directufone', 'userId': 0});
+         } else if (username === 'ufoneprom' && password === '6789') {
+                callback(null, true, {'username': 'ufoneprom', 'userId': 1});
+        }
+        else {
+                callback(null, false);
+        }
+};
+larvitsmpp.server({     'port': 2770,
+        'checkuserpass': checkuserpass
+}, function(err, serverSession) {
+        if (err) {
+                throw err;
+        }
+
+        // Incoming SMS!
+        serverSession.on('sms', function(sms) {
+                //              console.log(sms.session._events.myObject.incomingPdu);
+       // ADD THESE DEBUG LINES AT THE TOP ↓
+        console.log('sms object keys:', Object.keys(sms));
+        console.log('smsId:', sms.smsId);
+        console.log('smsId:test');
+        console.log('sequence_number:', sms.pduObj && sms.pduObj.cmdStatus);
+        console.log('full pduObj:', JSON.stringify(sms.pduObj, null, 2));
+
+                    //console.log('pduObjs:', JSON.stringify(sms.pduObjs, null, 2));
+                    //console.log('session keys:', Object.keys(sms.session));
+
+        // DEBUG LINES END ↑
+                var mnp_check = sms.to.substr(sms.to.length - 10);
+                mnp_check =0+mnp_check;
+                console.log(mnp_check);
+                client.get(mnp_check, function(err, reply) {
+                                status_mnp = reply;
+                                console.log(status_mnp);
+                        });
+
+                sms.sendResp(
+                        'ESME_ROK'
+                );
+
+
+                        console.log("THIS IS ELSE LOOP");
+                        number = sms.to;
+                var txt= urlencode(sms.message);
+                if(this.userData.userId == 0) {
+//                      url ='http://localhost/kannel/sendzong.php?to='+sms.to+'&from='+sms.from+'&message='+txt'&charset='+sms.charset'&sms.coding='+sms.encoding;
+                        url = 'http://host-IP/script_http.php?to=' + sms.to + '&from=' + sms.from + '&message=' + txt ;
+                } else if (this.userData.userId == 1){
+                                                //url = 'https://bsms.ufone.com/bsms_v8_api/sendapi-07.jsp?id=03315515021&message='+txt+'&shortcode='+sms.from+'&lang=English&mobilenum='+sms.to+'&password=March%402023&operator=Ufone&messagetype=nontransactional';
+                        url = 'http://host-IP/script_http_2.php?to=' + sms.to + '&from=' + sms.from + '&message=' + txt ;
+                }
+                var accessLog = {
+                        timeStamp: currentTime,
+                        to: sms.to,
+                        from: sms.from,
+                        message: txt,
+                        submitTime: sms.submitTime,
+                        //smsCount: sms.pduObjs.length,
+                        apiUrl: url,
+                        charset: this.dta_charset,      // Character set
+                        encoding: this.data_coding
+                };
+
+                request(url, {timeout: 60000} ,function (error, response, body) {
+                        console.log('body:', body);
+                        if (!error && response.statusCode == 200) {
+                                accessLog.apiResponse = body;
+                                        if (sms.dlr === true) {
+                                           if (body && body.indexOf('Successful') !== -1) {
+                                                   console.log('DELIVRD');
+                                                 sms.sendDlr('DELIVRD');
+                                                } else {
+                                                         sms.sendDlr('UNDELIV');
+                                                        console.log('UNDELIV');
+                                                }
+                                         }
+                        } else {
+                                accessLog.apiResponse = error;
+                        }
+                        log.info(accessLog);
+                });
+
+
+                // Oh, the sms sender wants a dlr (delivery report), send it!
+                //if (sms.dlr === true) {
+                //      sms.sendDlr('ACCEPTED'); // Equalent to sms.sendDlr('DELIVERED');
+
+                        // To send a negative delivery report for example do:
+                        // sms.sendDlr('UNDELIVERABLE');
+                        // Possible values are:
+                        // SCHEDULED
+                        // ENROUTE
+                        // DELIVERED <-- Default
+                        // EXPIRED
+                        // DELETED
+                        // UNDELIVERABLE
+                        // ACCEPTED
+                        // UNKNOWN
+                        // REJECTED
+                        // SKIPPED
+                //}
+        });
+});


### PR DESCRIPTION

## Summary
This PR fixes DLR delivery when larvitsmpp is used as an SMPP server
connected to Kannel SMS Gateway with Redis DLR storage.

## Problems & Fixes

**1. submit_sm_resp missing message_id (single part)**
Kannel requires a message_id in the submit_sm_resp to store the DLR
entry in Redis. Without it, DLRs can never be matched back.
Fix: generate UUID and return it in submit_sm_resp, store as smsId.

**2. submit_sm_resp missing message_id (multipart)**
longSms() returned early without ever sending submit_sm_resp.
Fix: generate UUID per part inside longSms(), send resp immediately,
store first part's ID on the group for the assembled smsObj.

**3. smsId never set on server-side smsObj**
smsDlr() silently bails out if smsId is undefined.
Fix: smsId now explicitly set on smsObj in both single and multipart paths.

**4. stat:UNDELIVERABLE violates SMPP v3.4 spec**
Spec requires stat field to be exactly 7 chars. UNDELIVERABLE is 13.
Kannel's sscanf parser rejects it and treats every DLR as DELIVRD.
Fix: changed to UNDELIV (7 chars) per spec.

## Tested
- Kannel + Redis DLR storage
- Single and multipart SMS
- DELIVRD and UNDELIV flows
- Verified via Wireshark PCAP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added detailed documentation of this fork with SMS handling improvements and DLR compatibility updates.

* **Bug Fixes**
  * Message IDs now properly generated and tracked for SMS submissions.
  * DLR status text corrected to specification-compliant format.
  * Improved multipart SMS delivery response handling.

* **Tests**
  * Added test application demonstrating SMPP server integration with example scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->